### PR TITLE
Plotting metadata returns default if country is not configured

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 0.0.9
+
+* Plotting metadata now returns default if country is missing from config
+
 # naomi 0.0.8
 
 * Iterate model options endpoint to be able to exclude optional data set options

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -11,8 +11,7 @@
 #'
 #' @examples
 #' get_plotting_metadata("Malawi")
-#' get_plotting_metadata()
-get_plotting_metadata <- function(country = "default") {
+get_plotting_metadata <- function(country) {
   metadata <- get_metadata()
   colour_scale <- get_colour_scale(country)
   if (nrow(colour_scale) == 0) {

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -1,6 +1,7 @@
-#' Get plotting metadata for a particualr country
+#' Get plotting metadata for a particular country
 #'
-#' @param country Country to get metadata for
+#' @param country Country to get metadata for or blank for default
+#' configuration.
 #'
 #' @return List of plotting metadata about how to locate data for a specific
 #' indicator, data type and plot type. Also returns metadata about colour
@@ -10,28 +11,33 @@
 #'
 #' @examples
 #' get_plotting_metadata("Malawi")
-get_plotting_metadata <- function(country) {
+#' get_plotting_metadata()
+get_plotting_metadata <- function(country = "default") {
   metadata <- get_metadata()
   colour_scale <- get_colour_scale(country)
+  if (nrow(colour_scale) == 0) {
+    message(sprintf(
+      "Country %s not in metadata - returning default colour scales.", country))
+    colour_scale <- get_colour_scale()
+  }
   merge(x = metadata, y = colour_scale, by = "indicator")
 }
 
 #' Get colour scale and ranges for a particular country
 #'
-#' @param country Country to get scale for
+#' @param country Country to get scale for or return default scale if left
+#' blank.
 #'
 #' @return List of scale information including colour as a d3 scale chromatic
 #' function name, whether to invert the scale and a min and max value for the
 #' scale.
 #'
 #' @keywords internal
-get_colour_scale <- function(country) {
+get_colour_scale <- function(country = "default") {
   scales <- naomi_read_csv(system_file("extdata", "meta", "colour_scales.csv"))
   data <- scales[tolower(scales$country) == tolower(country), ]
-  if (nrow(data) == 0) {
-    stop(sprintf(
-      "Can't retrieve colour scale for country %s. Country not found in configuration.",
-      country))
+  if (nrow(data) == 0 && country == "default") {
+    stop(sprintf("Can't retrieve default colour scale. Check configuration."))
   }
   data
 }

--- a/inst/extdata/meta/colour_scales.csv
+++ b/inst/extdata/meta/colour_scales.csv
@@ -1,4 +1,14 @@
 country,indicator,colour,min,max,invert_scale
+default,current_art,interpolateViridis,0,80000,FALSE
+default,prevalence,interpolateMagma,0,0.5,TRUE
+default,art_coverage,interpolateViridis,0,1,FALSE
+default,vls,interpolateWarm,0,1,FALSE
+default,recent,interpolatePlasma,0,0.6,TRUE
+default,art_number,interpolateViridis,0,70000,FALSE
+default,population,interpolateViridis,0,20000000,FALSE
+default,plhiv,interpolateMagma,0,10000000,TRUE
+default,incidence,interpolateMagma,0,0.01,TRUE
+default,new_infections,interpolateMagma,0,40000,TRUE
 Malawi,current_art,interpolateViridis,0,80000,FALSE
 Malawi,prevalence,interpolateMagma,0,0.5,TRUE
 Malawi,art_coverage,interpolateViridis,0,1,FALSE

--- a/man/get_colour_scale.Rd
+++ b/man/get_colour_scale.Rd
@@ -4,10 +4,11 @@
 \alias{get_colour_scale}
 \title{Get colour scale and ranges for a particular country}
 \usage{
-get_colour_scale(country)
+get_colour_scale(country = "default")
 }
 \arguments{
-\item{country}{Country to get scale for}
+\item{country}{Country to get scale for or return default scale if left
+blank.}
 }
 \value{
 List of scale information including colour as a d3 scale chromatic

--- a/man/get_plotting_metadata.Rd
+++ b/man/get_plotting_metadata.Rd
@@ -4,7 +4,7 @@
 \alias{get_plotting_metadata}
 \title{Get plotting metadata for a particular country}
 \usage{
-get_plotting_metadata(country = "default")
+get_plotting_metadata(country)
 }
 \arguments{
 \item{country}{Country to get metadata for or blank for default
@@ -20,5 +20,4 @@ Get plotting metadata for a particular country
 }
 \examples{
 get_plotting_metadata("Malawi")
-get_plotting_metadata()
 }

--- a/man/get_plotting_metadata.Rd
+++ b/man/get_plotting_metadata.Rd
@@ -2,12 +2,13 @@
 % Please edit documentation in R/metadata.R
 \name{get_plotting_metadata}
 \alias{get_plotting_metadata}
-\title{Get plotting metadata for a particualr country}
+\title{Get plotting metadata for a particular country}
 \usage{
-get_plotting_metadata(country)
+get_plotting_metadata(country = "default")
 }
 \arguments{
-\item{country}{Country to get metadata for}
+\item{country}{Country to get metadata for or blank for default
+configuration.}
 }
 \value{
 List of plotting metadata about how to locate data for a specific
@@ -15,8 +16,9 @@ indicator, data type and plot type. Also returns metadata about colour
 scheme to use for that country and indicator.
 }
 \description{
-Get plotting metadata for a particualr country
+Get plotting metadata for a particular country
 }
 \examples{
 get_plotting_metadata("Malawi")
+get_plotting_metadata()
 }

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -7,9 +7,28 @@ test_that("can retrieve indicator colour scales for a country", {
   expect_true(all(scale$country == "Malawi"))
 })
 
-test_that("getting scale for missing indicator or country returns error", {
-  expect_error(get_colour_scale("missing"),
-    "Can't retrieve colour scale for country missing. Country not found in configuration.")
+test_that("can retrieve default colour scales", {
+  scale <- get_colour_scale()
+  expect_true(all(c("country", "indicator", "colour", "min", "max",
+                    "invert_scale") %in% names(scale)))
+  expect_true(all(scale$country == "default"))
+})
+
+test_that("getting scale for missing country returns error empty data", {
+  missing <- get_colour_scale("missing")
+  expect_equal(names(missing),
+               c("country", "indicator", "colour", "min", "max","invert_scale"))
+  expect_equal(nrow(missing), 0)
+})
+
+test_that("default configuration missing throws an error", {
+  mock_naomi_read_csv <- mockery::mock(
+    data.frame(country = c("Malawi"), indicator = c("Test"),
+               stringsAsFactors = FALSE))
+  with_mock("naomi:::naomi_read_csv" = mock_naomi_read_csv, {
+    expect_error(get_colour_scale(),
+                 "Can't retrieve default colour scale. Check configuration.")
+  })
 })
 
 test_that("can get plot metadata for a country", {
@@ -19,6 +38,20 @@ test_that("can get plot metadata for a country", {
       "indicator_value", "name", "colour", "min", "max", "invert_scale") %in%
       names(metadata)))
   expect_true(all(unique(metadata$indicator) %in%
+                    c("art_coverage", "current_art",  "prevalence", "art_number",
+                      "incidence", "new_infections", "plhiv", "population",
+                      "recent", "vls")))
+})
+
+test_that("can get plot metadata for missing country with defaults", {
+  metadata <- testthat::evaluate_promise(get_plotting_metadata("missing"))
+  expect_equal(metadata$messages,
+    "Country missing not in metadata - returning default colour scales.\n")
+  expect_true(all(
+    c("indicator", "data_type", "plot_type", "value_column", "indicator_column",
+      "indicator_value", "name", "colour", "min", "max", "invert_scale") %in%
+      names(metadata$result)))
+  expect_true(all(unique(metadata$result$indicator) %in%
                     c("art_coverage", "current_art",  "prevalence", "art_number",
                       "incidence", "new_infections", "plhiv", "population",
                       "recent", "vls")))


### PR DESCRIPTION
This PR will

* Return a default from plotting metadata function if country is not found in configuration

@jeffeaton Can you review this from a min/max and colour scales POV? Would be good to have sensible defaults here