### PR TITLE
Rename default to value to match updated schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.10
+Version: 0.0.11
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 0.0.11
+
+* Fix issues with naomi model run options schema templates
+
 # naomi 0.0.10
 
 * Use iso3 to locate country plotting metadata instead of country name

--- a/inst/extdata/meta/anc_run_options.json
+++ b/inst/extdata/meta/anc_run_options.json
@@ -10,9 +10,8 @@
           "label": "Time 1",
           "type": "select",
           "helpText": "Quarter matching midpoint of survey",
-          "options": [
-            <anc_prevalence_t1_options>
-          ],
+          "options":
+            <anc_prevalence_t1_options>,
           "required": false
         },
         {
@@ -20,9 +19,8 @@
           "label": "Time 2",
           "type": "select",
           "helpText": "Quarter matching midpoint of survey",
-          "options": [
-            <anc_prevalence_t2_options>
-          ],
+          "options":
+            <anc_prevalence_t2_options>,
           "required": false
         }
       ]
@@ -35,9 +33,8 @@
           "label": "Time 1",
           "type": "select",
           "helpText": "Quarter matching midpoint of survey",
-          "options": [
-            <anc_art_coverage_t1_options>
-          ],
+          "options":
+            <anc_art_coverage_t1_options>,
           "required": false
         },
         {
@@ -45,9 +42,8 @@
           "label": "Time 2",
           "type": "select",
           "helpText": "Quarter matching midpoint of survey",
-          "options": [
-            <anc_art_coverage_t2_options>
-          ],
+          "options":
+            <anc_art_coverage_t2_options>,
           "required": false
         }
       ]

--- a/inst/extdata/meta/art_run_options.json
+++ b/inst/extdata/meta/art_run_options.json
@@ -10,9 +10,8 @@
           "label": "Year midpoint of survey",
           "type": "select",
           "helpText": "Select year of input ART data at the midpoint of survey data",
-          "options": [
-            <art_t1_options>
-          ],
+          "options":
+            <art_t1_options>,
           "required": false
         },
         {
@@ -20,9 +19,8 @@
           "label": "Year to generate estimates",
           "type": "select",
           "helpText": "Select year of input ART data at which to generate estimates",
-          "options": [
-            <art_t2_options>
-          ],
+          "options":
+            <art_t2_options>,
           "required": false
         }
       ]

--- a/inst/extdata/meta/general_run_options.json
+++ b/inst/extdata/meta/general_run_options.json
@@ -11,7 +11,7 @@
           "options": [
             <area_scope_options>
           ],
-          "default": <area_scope_default>,
+          "value": <area_scope_default>,
           "required": true
         }
       ]

--- a/inst/extdata/meta/general_run_options.json
+++ b/inst/extdata/meta/general_run_options.json
@@ -8,9 +8,8 @@
         {
           "name": "area_scope",
           "type": "multiselect",
-          "options": [
-            <area_scope_options>
-          ],
+          "options": 
+            <area_scope_options>,
           "value": <area_scope_default>,
           "required": true
         }
@@ -22,9 +21,8 @@
         {
           "name": "area_level",
           "type": "select",
-          "options": [
-            <area_level_options>
-          ],
+          "options": 
+            <area_level_options>,
           "required": true
         }
       ]
@@ -35,9 +33,8 @@
         {
           "name": "t1",
           "type": "select",
-          "options": [
-            <t1_options>
-          ],
+          "options": 
+            <t1_options>,
           "required": true
         }
       ]
@@ -48,9 +45,8 @@
         {
           "name": "t2",
           "type": "select",
-          "options": [
-            <t2_options>
-          ],
+          "options":
+            <t2_options>,
           "required": true
         }
       ]

--- a/inst/extdata/meta/survey_run_options.json
+++ b/inst/extdata/meta/survey_run_options.json
@@ -8,9 +8,8 @@
         {
           "name": "survey_prevalence",
           "type": "select",
-          "options": [
-            <survey_prevalence_options>
-          ],
+          "options":
+            <survey_prevalence_options>,
           "required": true
         }
       ]
@@ -21,9 +20,8 @@
         {
           "name": "survey_art_coverage",
           "type": "select",
-          "options": [
-            <survey_art_coverage_options>
-          ],
+          "options":
+            <survey_art_coverage_options>,
           "required": false
         }
       ]
@@ -34,9 +32,8 @@
         {
           "name": "survey_vls",
           "type": "select",
-          "options": [
-            <survey_vls_options>
-          ],
+          "options":
+            <survey_vls_options>,
           "required": false
         }
       ]
@@ -47,9 +44,8 @@
         {
           "name": "survey_recently_infected",
           "type": "select",
-          "options": [
-            <survey_recently_infected_options>
-          ],
+          "options":
+            <survey_recently_infected_options>,
           "required": false
         }
       ]
@@ -60,9 +56,8 @@
         {
           "name": "survey_art_or_vls",
           "type": "select",
-          "options": [
-            <survey_art_or_vls_options>
-          ],
+          "options":
+            <survey_art_or_vls_options>,
           "required": true
         }
       ]


### PR DESCRIPTION
So that the returned run options adhere to updated schema.

This also fixes typos noticed in the schema templates. I will add some more robust testing to hintr as that is failing to catch these problems