### PR TITLE
Expose no of samples option to allow quicker model run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.14
+Version: 0.0.15
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 0.0.15
+
+* Allow passing no of samples in model run options
+
 # naomi 0.0.14
 
 * Update progress message

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -20,7 +20,7 @@
 hintr_run_model <- function(data, options, output_path = tempfile(),
                             spectrum_path = tempfile(fileext = ".zip"),
                             summary_path = tempfile(fileext = ".zip")) {
-
+  INLA:::inla.dynload.workaround()
   progress <- new_progress()
   progress$start("Preparing input data")
   progress$print()

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -94,7 +94,7 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
   progress$complete("Fitting the model")
   progress$start("Generating uncertainty ranges")
   progress$print()
-  fit <- sample_tmb(fit)
+  fit <- sample_tmb(fit, nsample = options$no_of_samples)
 
   progress$complete("Generating uncertainty ranges")
   progress$start("Preparing outputs")

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -24,7 +24,8 @@ test_that("model can be run", {
     anc_prevalence_t1 = 464,
     anc_prevalence_t2 = 475,
     anc_art_coverage_t1 = 464,
-    anc_art_coverage_t2 = 475
+    anc_art_coverage_t2 = 475,
+    no_of_samples = 20
   )
   output_path <- tempfile()
   output_spectrum <- tempfile(fileext = ".zip")
@@ -75,7 +76,8 @@ test_that("model can be run without programme data", {
     survey_art_coverage = "MWI2016PHIA",
     survey_vls = NULL,
     survey_recently_infected = "MWI2016PHIA",
-    survey_art_or_vls = "art_coverage"
+    survey_art_or_vls = "art_coverage",
+    no_of_samples = 20
   )
   output_path <- tempfile()
   output_spectrum <- tempfile(fileext = ".zip")
@@ -136,7 +138,8 @@ test_that("progress messages are printed", {
     anc_prevalence_t1 = 464,
     anc_prevalence_t2 = 475,
     anc_art_coverage_t1 = 464,
-    anc_art_coverage_t2 = 475
+    anc_art_coverage_t2 = 475,
+    no_of_samples = 20
   )
   output_path <- tempfile()
   output_spectrum <- tempfile(fileext = ".zip")


### PR DESCRIPTION
This PR will

* Get no of samples from model run options and pass to `sample_tmb`

We know that the front end will combine the general options and the advanced options into one options list so this is the form we are expecting the front end to return