### PR TITLE
advanced fitting options support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.1
 Additional_repositories:
     https://inla.r-inla-download.org/R/stable,
     https://mrc-ide.github.io/drat

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Silent fitting for hintr_run_model() unless option outer_verbose = TRUE or inner_verbose = TRUE.
 * Specify maximum number of iterations for fit_tmb().
 * Warning if fit_tmb() convergence error.
+* hintr_run_model() throw error if convergence error, unless option$permissive = TRUE.
 
 # naomi 0.0.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Add model input validation step to hintr_run_model().
 * Implement random number seed argument to sample_tmb() to return exact same results.
 * Silent fitting for hintr_run_model() unless option outer_verbose = TRUE or inner_verbose = TRUE.
+* Specify maximum number of iterations for fit_tmb().
+* Warning if fit_tmb() convergence error.
 
 # naomi 0.0.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # naomi 0.0.21
 
 * Add model input validation step to hintr_run_model().
+* Implement random number seed argument to sample_tmb() to return exact same results.
 
 # naomi 0.0.20
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Add model input validation step to hintr_run_model().
 * Implement random number seed argument to sample_tmb() to return exact same results.
+* Silent fitting for hintr_run_model() unless option outer_verbose = TRUE or inner_verbose = TRUE.
 
 # naomi 0.0.20
 

--- a/R/model.R
+++ b/R/model.R
@@ -680,7 +680,8 @@ anc_testing_prev_mf <- function(year, anc_testing, naomi_mf) {
       area_id = character(0),
       anc_idx = integer(0),
       anc_prev_x = integer(0),
-      anc_prev_n = integer(0)
+      anc_prev_n = integer(0),
+      stringsAsFactors = FALSE
     )
   } else {
     anc_prev_dat <-
@@ -715,7 +716,8 @@ anc_testing_artcov_mf <- function(year, anc_testing, naomi_mf) {
       area_id = character(0),
       anc_idx = integer(0),
       anc_artcov_x = integer(0),
-      anc_artcov_n = integer(0)
+      anc_artcov_n = integer(0),
+      stringsAsFactors = FALSE
     )
   } else {
     anc_artcov_dat <-
@@ -773,7 +775,8 @@ artnum_mf <- function(calendar_quarter, art_number, naomi_mf) {
       sex = character(0),
       age_group_id = integer(0),
       artnum_idx = integer(0),
-      current_art = integer(0)
+      current_art = integer(0),
+      stringsAsFactors = FALSE
     )
   } else {
     ## !!! Note: should add some subsetting for sex and age group.

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -288,10 +288,10 @@ save_output <- function(filename, dir,
     naomi_output$meta_area$name <- naomi_output$meta_area$area_id
     if(!is.null(boundary_format) && !is.na(boundary_format)) {
       if(boundary_format == "geojson") {
-        sf::st_write(naomi_output$meta_area, "boundaries.geojson")
+        sf::st_write(naomi_output$meta_area, "boundaries.geojson", quiet = TRUE)
       } else if(boundary_format == "shp") {
         dir.create("shp")
-        sf::st_write(naomi_output$meta_area, "shp/boundaries.shp")
+        sf::st_write(naomi_output$meta_area, "shp/boundaries.shp", quiet = TRUE)
       } else {
         stop(paste("Boundary file format", boundary_format, "not recognized.",
                    "Please select 'geojson', 'shp', or NA to not save boundaries."))

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -133,7 +133,9 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
   progress$complete("Fitting the model")
   progress$start("Generating uncertainty ranges")
   progress$print()
-  fit <- sample_tmb(fit, nsample = options$no_of_samples)
+  fit <- sample_tmb(fit,
+                    nsample = options$no_of_samples,
+                    rng_seed = options$rng_seed)
 
   progress$complete("Generating uncertainty ranges")
   progress$start("Preparing outputs")

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -131,7 +131,14 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
 
   fit <- fit_tmb(tmb_inputs,
                  outer_verbose = ifelse(is.null(options$outer_verbose), FALSE, options$outer_verbose),
-                 inner_verbose = ifelse(is.null(options$inner_verbose), FALSE, options$inner_verbose))
+                 inner_verbose = ifelse(is.null(options$inner_verbose), FALSE, options$inner_verbose),
+                 max_iter = ifelse(is.null(options$max_iterations), 250, options$max_iterations))
+
+  if(is.null(options$permissive))
+    options$permissive <- FALSE
+
+  if(fit$convergence != 0 && options$permissive == FALSE)
+    stop(paste("convergence error:", fit$message))
                  
   progress$complete("Fitting the model")
   progress$start("Generating uncertainty ranges")

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -128,8 +128,11 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
   progress$complete("Preparing input data")
   progress$start("Fitting the model")
   progress$print()
-  fit <- fit_tmb(tmb_inputs)
 
+  fit <- fit_tmb(tmb_inputs,
+                 outer_verbose = ifelse(is.null(options$outer_verbose), FALSE, options$outer_verbose),
+                 inner_verbose = ifelse(is.null(options$inner_verbose), FALSE, options$inner_verbose))
+                 
   progress$complete("Fitting the model")
   progress$start("Generating uncertainty ranges")
   progress$print()

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -232,10 +232,15 @@ prepare_tmb_inputs <- function(naomi_data) {
 #' @param tmb_input Model input data
 #' @param outer_verbose If TRUE print function and parameters every iteration
 #' @param inner_verbose If TRUE then disable tracing information from TMB
+#' @param max_iter maximum number of iterations
 #'
 #' @return Fit model.
 #' @export
-fit_tmb <- function(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE) {
+fit_tmb <- function(tmb_input,
+                    outer_verbose = TRUE,
+                    inner_verbose = FALSE,
+                    max_iter = 250
+                    ) {
 
   stopifnot(inherits(tmb_input, "naomi_tmb_input"))
 
@@ -263,8 +268,13 @@ fit_tmb <- function(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE) {
                                    "oddsratio_gamma_art_raw"))
 
   trace <- if(outer_verbose) 1 else 0
-  f <- stats::nlminb(obj$par, obj$fn, obj$gr, control = list(trace = trace))
+  f <- stats::nlminb(obj$par, obj$fn, obj$gr,
+                     control = list(trace = trace,
+                                    iter.max = max_iter))
 
+  if(f$convergence != 0)
+    warning(paste("convergence error:", f$message))
+  
   f$par.fixed <- f$par
   f$par.full <- obj$env$last.par
 

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -294,13 +294,17 @@ report_tmb <- function(naomi_fit) {
 #'
 #' @param fit The TMB fit
 #' @param nsample Number of samples
+#' @param rng_seed seed passed to set.seed.
 #' @param random_only Random only
 #' @param verbose If TRUE prints additional information.
 #'
 #' @return Sampled fit.
 #' @export
-sample_tmb <- function(fit, nsample = 1000, random_only = TRUE, verbose = TRUE) {
+sample_tmb <- function(fit, nsample = 1000, rng_seed = NULL,
+                       random_only = TRUE, verbose = TRUE) {
 
+  set.seed(rng_seed)
+  
   stopifnot(methods::is(fit, "naomi_fit"))
   stopifnot(nsample > 1)
 

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -301,7 +301,7 @@ report_tmb <- function(naomi_fit) {
 #' @return Sampled fit.
 #' @export
 sample_tmb <- function(fit, nsample = 1000, rng_seed = NULL,
-                       random_only = TRUE, verbose = TRUE) {
+                       random_only = TRUE, verbose = FALSE) {
 
   set.seed(rng_seed)
   

--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -145,43 +145,44 @@
     "controlGroups": []
 },
 {
-  "label": "Advanced",
-  "description": "Advanced model run options",
-  "controlGroups": [
-    {
-      "label": "Maximum iterations",
-      "controls": [
-        {
-          "name": "max_iterations",
-          "type": "number",
-          "value": 250,
-          "helpText": "Maximum number of iteration for model run",
-          "required": true
-        }
-      ]
-    },
-    {
-      "label": "Number of simulations",
-      "controls": [
-        {
-          "name": "no_of_samples",
-          "type": "number",
-          "value": 1000,
-          "helpText": "Number of simulatons for generating uncertainty ranges",
-          "required": true
-        }
-      ]
-    },
-    {
-      "label": "Simulation seed",
-      "controls": [
-        {
-            "name": "rng_seed",
-            "type": "number",
-            "value": 28,
-            "required": false,
-	    "helpText": "Random number generator seed for uncertainty sample"
-        }
-      ]
-    }
+    "label": "Advanced",
+    "description": "Advanced model run options",
+    "controlGroups": [
+	{
+	    "label": "Maximum iterations",
+	    "controls": [
+		{
+		    "name": "max_iterations",
+		    "type": "number",
+		    "value": 250,
+		    "helpText": "Maximum number of iteration for model run",
+		    "required": true
+		}
+	    ]
+	},
+	{
+	    "label": "Number of simulations",
+	    "controls": [
+		{
+		    "name": "no_of_samples",
+		    "type": "number",
+		    "value": 1000,
+		    "helpText": "Number of simulatons for generating uncertainty ranges",
+		    "required": true
+		}
+	    ]
+	},
+	{
+	    "label": "Simulation seed",
+	    "controls": [
+		{
+		    "name": "rng_seed",
+		    "type": "number",
+		    "value": 28,
+		    "required": false,
+		    "helpText": "Random number generator seed for uncertainty sample"
+		}
+	    ]
+	}
+    ]
 }

--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -173,40 +173,15 @@
       ]
     },
     {
-      "label": "Cross-district ART attendance",
+      "label": "Simulation seed",
       "controls": [
         {
-          "name": "art_attendance",
-          "type": "select",
-          "options":
-            [{
-              "id": "true",
-              "label": "true"
-            },
-            {
-              "id": "false",
-              "label": "false"
-            }],
-          "value": "false",
-          "required": true
-        }
-      ]
-    },
-    {
-      "label": "Prevalence model choice",
-      "controls": [
-        {
-          "name": "prevalence_model_choice",
-          "type": "select",
-          "options":
-            [{
-              "id": "static",
-              "label": "static"
-            }],
-          "value": "static",
-          "required": true
+            "name": "rng_seed",
+            "type": "number",
+            "value": 28,
+            "required": false,
+	    "helpText": "Random number generator seed for uncertainty sample"
         }
       ]
     }
-  ]
 }

--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -183,6 +183,29 @@
 		    "helpText": "Random number generator seed for uncertainty sample"
 		}
 	    ]
+	},
+	{
+	    "label": "Permissive",
+	    "controls": [
+		{
+		    "name": "permissive",
+		    "type": "select",
+		    "required": true,
+		    "options":
+		    [
+			{
+			    "id": "true",
+			    "label": "Yes"
+			},
+			{
+			    "id": "false",
+			    "label": "No"
+			}
+		    ],
+		    "value": "false",
+		    "helpText": "Select 'Yes' to allow fits with convergence or data errors."
+		}
+	    ]
 	}
     ]
 }

--- a/man/calc_survey_hiv_indicators.Rd
+++ b/man/calc_survey_hiv_indicators.Rd
@@ -4,10 +4,18 @@
 \alias{calc_survey_hiv_indicators}
 \title{Calculate age/sex/area stratified survey estimates for biomarker outcomes}
 \usage{
-calc_survey_hiv_indicators(survey_meta, survey_regions, survey_clusters,
-  survey_individuals, survey_biomarker, areas, sex = c("male", "female",
-  "both"), age_group_id = NULL, area_top_level = min(areas$area_level),
-  area_bottom_level = max(areas$area_level))
+calc_survey_hiv_indicators(
+  survey_meta,
+  survey_regions,
+  survey_clusters,
+  survey_individuals,
+  survey_biomarker,
+  areas,
+  sex = c("male", "female", "both"),
+  age_group_id = NULL,
+  area_top_level = min(areas$area_level),
+  area_bottom_level = max(areas$area_level)
+)
 }
 \arguments{
 \item{survey_meta}{Survey metadata.}

--- a/man/create_areas.Rd
+++ b/man/create_areas.Rd
@@ -4,8 +4,12 @@
 \alias{create_areas}
 \title{Create an Areas Object}
 \usage{
-create_areas(levels = NULL, hierarchy = NULL, boundaries = NULL,
-  area_merged = NULL)
+create_areas(
+  levels = NULL,
+  hierarchy = NULL,
+  boundaries = NULL,
+  area_merged = NULL
+)
 }
 \arguments{
 \item{levels}{Data frame of area level metadata.}

--- a/man/cut_naomi_age_group.Rd
+++ b/man/cut_naomi_age_group.Rd
@@ -13,7 +13,7 @@ cut_naomi_age_group(age)
 a vector of strings with five year age groups.
 }
 \description{
-Wrapper for \code{[cut()]} to return five year age groups with
+Wrapper for \verb{[cut()]} to return five year age groups with
 }
 \seealso{
 get_age_groups

--- a/man/expand_survey_clusters.Rd
+++ b/man/expand_survey_clusters.Rd
@@ -4,9 +4,13 @@
 \alias{expand_survey_clusters}
 \title{Expand list of clusters at each area level}
 \usage{
-expand_survey_clusters(survey_clusters, survey_regions, areas,
+expand_survey_clusters(
+  survey_clusters,
+  survey_regions,
+  areas,
   top_level = min(areas$area_level),
-  bottom_level = max(areas$area_level))
+  bottom_level = max(areas$area_level)
+)
 }
 \description{
 This function recursively expands the list of clusters to produce a list

--- a/man/fit_tmb.Rd
+++ b/man/fit_tmb.Rd
@@ -4,7 +4,7 @@
 \alias{fit_tmb}
 \title{Fit TMB model}
 \usage{
-fit_tmb(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE)
+fit_tmb(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE, max_iter = 250)
 }
 \arguments{
 \item{tmb_input}{Model input data}
@@ -12,6 +12,8 @@ fit_tmb(tmb_input, outer_verbose = TRUE, inner_verbose = FALSE)
 \item{outer_verbose}{If TRUE print function and parameters every iteration}
 
 \item{inner_verbose}{If TRUE then disable tracing information from TMB}
+
+\item{max_iter}{maximum number of iterations}
 }
 \value{
 Fit model.

--- a/man/get_area_collection.Rd
+++ b/man/get_area_collection.Rd
@@ -40,8 +40,8 @@ TODO: Should be an example - where is mwi_areas, mwi_area_geom?
 data(mwi_areas, mwi_area_geom)
 
 areas <- get_area_collection(mwi_areas, level = 3, area_scope = c("MWI.1", "MWI.3.5"))
-areas %>%
-left_join(mwi_area_geom %>% filter(type == "boundary")) %>%
-sf::st_as_sf() %>%
+areas \%>\%
+left_join(mwi_area_geom \%>\% filter(type == "boundary")) \%>\%
+sf::st_as_sf() \%>\%
 ggplot() + geom_sf()
 }

--- a/man/hintr_run_model.Rd
+++ b/man/hintr_run_model.Rd
@@ -4,9 +4,13 @@
 \alias{hintr_run_model}
 \title{Run the model and save output to file}
 \usage{
-hintr_run_model(data, options, output_path = tempfile(),
+hintr_run_model(
+  data,
+  options,
+  output_path = tempfile(),
   spectrum_path = tempfile(fileext = ".zip"),
-  summary_path = tempfile(fileext = ".zip"))
+  summary_path = tempfile(fileext = ".zip")
+)
 }
 \arguments{
 \item{data}{List of paths to input data files.}
@@ -32,7 +36,7 @@ The \code{data} argument must be a list specifying paths to the following:
 \item \code{pjnz}
 \item \code{shape}
 \item \code{population}
-\item \code{survey data}
+\item \verb{survey data}
 \item \code{anc_testing} (optional)
 \item \code{art_number} (optional)
 }

--- a/man/mwi_anc_testing.Rd
+++ b/man/mwi_anc_testing.Rd
@@ -70,7 +70,7 @@ M&E System.
 }
 
 The number of ART by age 0-14 and age 15+ is not reported in aggregate quarterly
-reporting data. For model illustration purposes, this is approximated as 94% of
+reporting data. For model illustration purposes, this is approximated as 94\% of
 all ART clients are age 15+ based on Spectrum model outputs which were validated
 against age distributions from electronic medical records by the Malawi HIV
 estimates team.

--- a/man/naomi_model_frame.Rd
+++ b/man/naomi_model_frame.Rd
@@ -4,15 +4,25 @@
 \alias{naomi_model_frame}
 \title{Construct Model Frames and Adjacency Structures}
 \usage{
-naomi_model_frame(area_merged, population_agesex, spec,
+naomi_model_frame(
+  area_merged,
+  population_agesex,
+  spec,
   scope = areas$tree$area_id,
-  level = max(areas$tree$Get("area_level")), calendar_quarter1,
-  calendar_quarter2, age_group_ids = 1:17, sexes = c("male", "female"),
-  omega = 0.7, rita_param = list(OmegaT0 = 130/365, sigma_OmegaT =
-  ((142 - 118)/365)/(2 * qnorm(0.975)), betaT0 = 0, sigma_betaT = 1e-05,
-  ritaT = 1), sigma_u_sd = 1, artattend = FALSE,
-  artattend_prior_sigma_scale = 3, logit_nu_mean = 2,
-  logit_nu_sd = 0.3)
+  level = max(areas$tree$Get("area_level")),
+  calendar_quarter1,
+  calendar_quarter2,
+  age_group_ids = 1:17,
+  sexes = c("male", "female"),
+  omega = 0.7,
+  rita_param = list(OmegaT0 = 130/365, sigma_OmegaT = ((142 - 118)/365)/(2 *
+    qnorm(0.975)), betaT0 = 0, sigma_betaT = 1e-05, ritaT = 1),
+  sigma_u_sd = 1,
+  artattend = FALSE,
+  artattend_prior_sigma_scale = 3,
+  logit_nu_mean = 2,
+  logit_nu_sd = 0.3
+)
 }
 \arguments{
 \item{area_merged}{Merged version of area hierarchy}

--- a/man/sample_tmb.Rd
+++ b/man/sample_tmb.Rd
@@ -4,12 +4,20 @@
 \alias{sample_tmb}
 \title{Sample TMB fit}
 \usage{
-sample_tmb(fit, nsample = 1000, random_only = TRUE, verbose = TRUE)
+sample_tmb(
+  fit,
+  nsample = 1000,
+  rng_seed = NULL,
+  random_only = TRUE,
+  verbose = FALSE
+)
 }
 \arguments{
 \item{fit}{The TMB fit}
 
 \item{nsample}{Number of samples}
+
+\item{rng_seed}{seed passed to set.seed.}
 
 \item{random_only}{Random only}
 

--- a/man/save_output_package.Rd
+++ b/man/save_output_package.Rd
@@ -5,9 +5,15 @@
 \alias{read_output_package}
 \title{Save outputs to zip file}
 \usage{
-save_output_package(naomi_output, filename, dir, overwrite = FALSE,
-  with_labels = FALSE, boundary_format = "geojson",
-  single_csv = FALSE)
+save_output_package(
+  naomi_output,
+  filename,
+  dir,
+  overwrite = FALSE,
+  with_labels = FALSE,
+  boundary_format = "geojson",
+  single_csv = FALSE
+)
 
 read_output_package(path)
 }

--- a/man/sdreport_joint_precision.Rd
+++ b/man/sdreport_joint_precision.Rd
@@ -4,10 +4,15 @@
 \alias{sdreport_joint_precision}
 \title{Get Joint Precision of TMB Fixed and Random}
 \usage{
-sdreport_joint_precision(obj, par.fixed = NULL, hessian.fixed = NULL,
-  bias.correct = FALSE, bias.correct.control = list(sd = FALSE, split =
-  NULL, nsplit = NULL), ignore.parm.uncertainty = FALSE,
-  skip.delta.method = FALSE)
+sdreport_joint_precision(
+  obj,
+  par.fixed = NULL,
+  hessian.fixed = NULL,
+  bias.correct = FALSE,
+  bias.correct.control = list(sd = FALSE, split = NULL, nsplit = NULL),
+  ignore.parm.uncertainty = FALSE,
+  skip.delta.method = FALSE
+)
 }
 \arguments{
 \item{obj}{Object returned by \code{MakeADFun}}
@@ -25,6 +30,6 @@ sdreport_joint_precision(obj, par.fixed = NULL, hessian.fixed = NULL,
 \item{skip.delta.method}{Skip the delta method? (\code{FALSE} by default)}
 }
 \description{
-This is a copy of \code{[TMB::sdreport]} that removes all computations of \code{ADREPORT()}ed variables to only return the joint precision.
+This is a copy of \verb{[TMB::sdreport]} that removes all computations of \code{ADREPORT()}ed variables to only return the joint precision.
 }
 \keyword{internal}

--- a/man/select_naomi_data.Rd
+++ b/man/select_naomi_data.Rd
@@ -4,15 +4,24 @@
 \alias{select_naomi_data}
 \title{Select data for model fitting}
 \usage{
-select_naomi_data(naomi_mf, survey_hiv_indicators, anc_testing, art_number,
-  prev_survey_ids, artcov_survey_ids, recent_survey_ids,
+select_naomi_data(
+  naomi_mf,
+  survey_hiv_indicators,
+  anc_testing,
+  art_number,
+  prev_survey_ids,
+  artcov_survey_ids,
+  recent_survey_ids,
   vls_survey_ids = NULL,
   artnum_calendar_quarter_t1 = naomi_mf$calendar_quarter1,
   artnum_calendar_quarter_t2 = naomi_mf$calendar_quarter2,
-  anc_prev_year_t1 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter1)),
-  anc_prev_year_t2 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter2)),
+ 
+    anc_prev_year_t1 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter1)),
+ 
+    anc_prev_year_t2 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter2)),
   anc_artcov_year_t1 = anc_prev_year_t1,
-  anc_artcov_year_t2 = anc_prev_year_t2)
+  anc_artcov_year_t2 = anc_prev_year_t2
+)
 }
 \arguments{
 \item{naomi_mf}{A Naomi model frame object.}
@@ -47,7 +56,7 @@ select_naomi_data(naomi_mf, survey_hiv_indicators, anc_testing, art_number,
 Select data for model fitting
 }
 \details{
-See example datasets for examples of required template for data sets. *\code{_survey_ids} must be reflected
+See example datasets for examples of required template for data sets. *\verb{_survey_ids} must be reflected
 in \code{survey_hiv_indicators}.
 
 ART coverage and VLS survey data should not be included from the same survey. This is checked

--- a/man/spread_areas.Rd
+++ b/man/spread_areas.Rd
@@ -4,8 +4,11 @@
 \alias{spread_areas}
 \title{Spread area hierarchy to wide format}
 \usage{
-spread_areas(areas, min_level = min(areas$area_level),
-  max_level = max(areas$area_level))
+spread_areas(
+  areas,
+  min_level = min(areas$area_level),
+  max_level = max(areas$area_level)
+)
 }
 \arguments{
 \item{areas}{area hierarchy data.frame}

--- a/man/survey_prevalence_mf.Rd
+++ b/man/survey_prevalence_mf.Rd
@@ -13,8 +13,13 @@ survey_artcov_mf(survey_ids, survey_hiv_indicators, naomi_mf)
 
 survey_vls_mf(survey_ids, survey_hiv_indicators, naomi_mf)
 
-survey_recent_mf(survey_ids, survey_hiv_indicators, naomi_mf,
-  min_age = 15, max_age = 80)
+survey_recent_mf(
+  survey_ids,
+  survey_hiv_indicators,
+  naomi_mf,
+  min_age = 15,
+  max_age = 80
+)
 }
 \arguments{
 \item{survey_ids}{Survey IDs}

--- a/tests/testthat/setup-model-frame.R
+++ b/tests/testthat/setup-model-frame.R
@@ -22,6 +22,6 @@ a_naomi_data <- select_naomi_data(a_naomi_mf,
 
                                                       
 a_tmb_inputs <- prepare_tmb_inputs(a_naomi_data)
-a_fit <- fit_tmb(a_tmb_inputs)
+a_fit <- fit_tmb(a_tmb_inputs, outer_verbose = FALSE)
 a_fit_sample <- sample_tmb(a_fit, nsample = 30, rng_seed = 28)
 a_output <- output_package(a_fit_sample, a_naomi_mf, area_merged)

--- a/tests/testthat/setup-model-frame.R
+++ b/tests/testthat/setup-model-frame.R
@@ -4,10 +4,24 @@ area_merged <- sf::read_sf(system.file("extdata/areas/area_merged.geojson", pack
 spec <- extract_pjnz_naomi(system.file("extdata/mwi2019.PJNZ", package = "naomi"))
 
 
-naomi_mf <- naomi_model_frame(area_merged,
+a_naomi_mf <- naomi_model_frame(area_merged,
                               mwi_population_agesex,
                               spec,
-                              scope = "MWI",
+                              scope = "MWI_1_1",
                               level = 4,
                               calendar_quarter1 = "CY2016Q1",
                               calendar_quarter2 = "CY2018Q3")
+
+a_naomi_data <- select_naomi_data(a_naomi_mf,
+                                  mwi_survey_hiv_indicators,
+                                  mwi_anc_testing,
+                                  mwi_art_number,
+                                  prev_survey_ids = c("MWI2016PHIA", "MWI2015DHS"),
+                                  artcov_survey_ids = "MWI2016PHIA",
+                                  recent_survey_ids = "MWI2016PHIA")
+
+                                                      
+a_tmb_inputs <- prepare_tmb_inputs(a_naomi_data)
+a_fit <- fit_tmb(a_tmb_inputs)
+a_fit_sample <- sample_tmb(a_fit, nsample = 30, rng_seed = 28)
+a_output <- output_package(a_fit_sample, a_naomi_mf, area_merged)

--- a/tests/testthat/test-model-fit.R
+++ b/tests/testthat/test-model-fit.R
@@ -1,0 +1,25 @@
+context("test-model-fit")
+
+test_that("setting rng_seed returns same outputs", {
+
+  a_fit_sample2 <- sample_tmb(a_fit, nsample = 30, rng_seed = 28)
+  a_output2 <- output_package(a_fit_sample2, a_naomi_mf, area_merged)
+
+  expect_equal(a_fit_sample$sample, a_fit_sample2$sample)
+  expect_equal(a_output$indicators$mean, a_output2$indicators$mean)
+})
+
+test_that("setting different rng_seed returns different output", {
+
+  a_fit_sample3 <- sample_tmb(a_fit, nsample = 30, rng_seed = 1)
+  expect_true(
+    a_fit_sample$sample$artnum_t1_out[1] !=
+    a_fit_sample3$sample$artnum_t1_out[1]
+  )
+
+  a_fit_sample_null <- sample_tmb(a_fit, nsample = 30)
+  expect_true(
+    a_fit_sample$sample$artnum_t1_out[1] !=
+    a_fit_sample_null$sample$artnum_t1_out[1]
+  )
+})

--- a/tests/testthat/test-model-fit.R
+++ b/tests/testthat/test-model-fit.R
@@ -23,3 +23,9 @@ test_that("setting different rng_seed returns different output", {
     a_fit_sample_null$sample$artnum_t1_out[1]
   )
 })
+
+test_that("exceeding maximum iterations throws a warning", {
+  expect_warning(fit_tmb(a_tmb_inputs, outer_verbose = FALSE, max_iter = 5),
+                 "iteration limit reached")
+})
+

--- a/tests/testthat/test-model-frame.R
+++ b/tests/testthat/test-model-frame.R
@@ -8,18 +8,18 @@ test_that("get_age_group_id_out() returns expected groups", {
 })
 
 test_that("artnum_mf() returns expected number of records", {
-  expect_equal(nrow(artnum_mf("CY2016Q1", NULL, naomi_mf)), 0L)
-  expect_equal(nrow(artnum_mf(NULL, mwi_art_number, naomi_mf)), 0L)
-  expect_equal(nrow(artnum_mf("CY2016Q1", NULL, naomi_mf)), 0L)
-  expect_named(artnum_mf(NULL, mwi_art_number, naomi_mf), 
+  expect_equal(nrow(artnum_mf("CY2016Q1", NULL, a_naomi_mf)), 0L)
+  expect_equal(nrow(artnum_mf(NULL, mwi_art_number, a_naomi_mf)), 0L)
+  expect_equal(nrow(artnum_mf("CY2016Q1", NULL, a_naomi_mf)), 0L)
+  expect_named(artnum_mf(NULL, mwi_art_number, a_naomi_mf), 
                c("area_id", "sex", "age_group_id", "artnum_idx", "current_art"))
-  expect_equal(nrow(artnum_mf("CY2016Q1", mwi_art_number, naomi_mf)), 64L)
-  expect_named(artnum_mf("CY2016Q1", mwi_art_number, naomi_mf), 
+  expect_equal(nrow(artnum_mf("CY2016Q1", mwi_art_number, a_naomi_mf)), 14L)
+  expect_named(artnum_mf("CY2016Q1", mwi_art_number, a_naomi_mf), 
                c("area_id", "sex", "age_group_id", "artnum_idx", "current_art"))
 })
 
 test_that("artnum_mf() throws errors for invalid inputs", {
-  expect_error(artnum_mf("CY1924Q4", mwi_art_number, naomi_mf))
+  expect_error(artnum_mf("CY1924Q4", mwi_art_number, a_naomi_mf))
   expect_error(artnum_mf("CY2016Q1", mwi_art_number, "jibberish"))
   expect_error(artnum_mf(c("CY2016Q1", "CY2016Q2"), mwi_art_number, "jibberish"))
 })

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -246,3 +246,32 @@ test_that("setting rng_seed returns same output", {
   expect_true(output$mean[output$indicator == "prevalence"][1] !=
               output3$mean[output3$indicator == "prevalence"][1])
 })
+
+test_that("exceeding max_iterations convergence error or warning", {
+
+  data <- a_hintr_data
+  
+  options <- a_hintr_options
+  options$survey_prevalence = "MWI2016PHIA"
+  options$survey_art_coverage <- NULL
+  options$survey_recently_infected <- NULL
+  options$include_art_t1 = "false"
+  options$include_art_t2 = "false"
+  options$max_iterations <- 5
+
+  output_path <- tempfile()
+  output_spectrum <- tempfile(fileext = ".zip")
+  summary_path <- tempfile(fileext = ".zip")
+
+  expect_error(hintr_run_model(data, options,
+                               output_path, output_spectrum,
+                               summary_path))
+
+  options$permissive <- TRUE
+  output_path <- tempfile()
+  output_spectrum <- tempfile(fileext = ".zip")
+  summary_path <- tempfile(fileext = ".zip")
+  expect_warning(hintr_run_model(data, options,
+                                 output_path, output_spectrum,
+                                 summary_path))
+})

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -218,3 +218,71 @@ test_that("model run throws error for invalid inputs", {
                     summary_path)
   )
 })
+
+
+test_that("setting rng_seed returns same output", {
+
+  data <- list(
+    pjnz = system_file("extdata/mwi2019.PJNZ"),
+    population = system_file("extdata/population/population_agesex.csv"),
+    shape = system_file("extdata/areas/area_merged.geojson"),
+    survey = system_file("extdata/survey/survey_hiv_indicators.csv"),
+    art_number = system_file("extdata/programme/art_number.csv"),
+    anc_testing = system_file("extdata/programme/anc_testing.csv")
+  )
+  options <- list(
+    area_scope = "MWI_1_1",
+    area_level = 4,
+    calendar_quarter_t1 = "CY2016Q1",
+    calendar_quarter_t2 = "CY2018Q3",
+    survey_prevalence = "MWI2016PHIA",
+    survey_art_coverage = NULL,
+    survey_recently_infected = NULL,
+    include_art_t1 = "false",
+    include_art_t2 = "false",
+    anc_prevalence_year1 = 2016,
+    anc_prevalence_year2 = 2018,
+    anc_art_coverage_year1 = 2016,
+    anc_art_coverage_year2 = 2018,
+    artattend = FALSE,
+    rng_seed = 17,
+    no_of_samples = 20
+  )
+
+  output_path <- tempfile()
+  output_spectrum <- tempfile(fileext = ".zip")
+  summary_path <- tempfile(fileext = ".zip")
+
+  model_run <- hintr_run_model(data, options, output_path, output_spectrum,
+                               summary_path)
+
+  options2 <- options
+  options2$rng_seed <- 17
+
+  output_path2 <- tempfile()
+  output_spectrum2 <- tempfile(fileext = ".zip")
+  summary_path2 <- tempfile(fileext = ".zip")
+
+  model_run2 <- hintr_run_model(data, options2, output_path2,
+                                output_spectrum2, summary_path2)
+
+  options3 <- options
+  options3$rng_seed <- NULL
+
+  output_path3 <- tempfile()
+  output_spectrum3 <- tempfile(fileext = ".zip")
+  summary_path3 <- tempfile(fileext = ".zip")
+
+  model_run3 <- hintr_run_model(data, options3, output_path3,
+                                output_spectrum3, summary_path3)
+
+  output <- readRDS(model_run$output_path)
+  output2 <- readRDS(model_run2$output_path)
+  output3 <- readRDS(model_run3$output_path)
+
+  expect_equal(output, output2)
+
+  expect_equal(nrow(output), nrow(output3))
+  expect_true(output$mean[output$indicator == "prevalence"][1] !=
+              output3$mean[output3$indicator == "prevalence"][1])
+})


### PR DESCRIPTION
Add support for advanced fitting options:

* Use max_iterations option to specify maximum iterations for optimizer.
* Sed a RNG seed for uncertainty sample simulation so same data --> same outputs.
* `fit_tmb()` gives a warning for convergence errors. `hintr_run_model()` throws an error for convergence errors, unless `option$permissive = TRUE`. 
* Fitting functions are quiet by default.
* Clear some `dplyr` `factor`/`character` join warnings and make `sf::st_write(..., quiet=TRUE)`.
* Restructure `test-run-model.R` to have a global default `data` and `option` set to avoid copy/paste for new tests -> more streamlined updating for added options.
* Inadvertently upgraded to Roxygen 7.0.1 which rewrote much documentation.

This can either be merged into #36 and consider altogether, or merge #36 and then this one.

I am particularly proud of this PR because I wrote tests for the new functionality, so please give some praise for that even if you dislike the rest of it.

Locally this passes `hintr` tests with version on mrc-ide/hintr#93.  I tried to create a separate hintr PR pointing to this branch to run Travis checks (mrc-ide/hintr#94), but think I did not do it right.

