### PR TITLE
remove time 2 ANC data -- fails if different areas have data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.29
+Version: 0.0.30
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 0.0.30
+
+* Undo ANC prevalence and ART coverage at time 2 which errors for different areas at two time points. Fix coming later.
+
 # naomi 0.0.29
 
 * Patch model validation for options$include_art_t1 = NULL.

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -426,17 +426,17 @@ Type objective_function<Type>::operator() ()
   mu_anc_alpha_t1 = logit(mu_anc_alpha_t1) + X_ancalpha * beta_anc_alpha + Z_ancalpha_x * ui_anc_alpha_x * sigma_ancalpha_x;
   val -= sum(dbinom_robust(x_anc_artcov_t1, n_anc_artcov_t1, mu_anc_alpha_t1, true));
 
-  vector<Type> mu_anc_rho_t2(A_anc_prev_t2 * rho_t2 / (A_anc_prev_t2 * ones));
-  mu_anc_rho_t2 = logit(mu_anc_rho_t2) +
-    X_ancrho * vector<Type>(beta_anc_rho + beta_anc_rho_t2) +
-    Z_ancrho_x * vector<Type>(ui_anc_rho_x * sigma_ancrho_x + ui_anc_rho_xt * sigma_ancrho_xt);
-  val -= sum(dbinom_robust(x_anc_prev_t2, n_anc_prev_t2, mu_anc_rho_t2, true));
+  // vector<Type> mu_anc_rho_t2(A_anc_prev_t2 * rho_t2 / (A_anc_prev_t2 * ones));
+  // mu_anc_rho_t2 = logit(mu_anc_rho_t2) +
+  //   X_ancrho * vector<Type>(beta_anc_rho + beta_anc_rho_t2) +
+  //   Z_ancrho_x * vector<Type>(ui_anc_rho_x * sigma_ancrho_x + ui_anc_rho_xt * sigma_ancrho_xt);
+  // val -= sum(dbinom_robust(x_anc_prev_t2, n_anc_prev_t2, mu_anc_rho_t2, true));
 
-  vector<Type> mu_anc_alpha_t2(A_anc_artcov_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_artcov_t2 * rho_t2));
-  mu_anc_alpha_t2 = logit(mu_anc_alpha_t2) +
-    X_ancalpha * vector<Type>(beta_anc_alpha + beta_anc_alpha_t2) +
-    Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);
-  val -= sum(dbinom_robust(x_anc_artcov_t2, n_anc_artcov_t2, mu_anc_alpha_t2, true));
+  // vector<Type> mu_anc_alpha_t2(A_anc_artcov_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_artcov_t2 * rho_t2));
+  // mu_anc_alpha_t2 = logit(mu_anc_alpha_t2) +
+  //   X_ancalpha * vector<Type>(beta_anc_alpha + beta_anc_alpha_t2) +
+  //   Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);
+  // val -= sum(dbinom_robust(x_anc_artcov_t2, n_anc_artcov_t2, mu_anc_alpha_t2, true));
 
 
   // * ART attendance model *
@@ -544,8 +544,8 @@ Type objective_function<Type>::operator() ()
   REPORT(mu_anc_rho_t1);
   REPORT(mu_anc_alpha_t1);
 
-  REPORT(mu_anc_rho_t2);
-  REPORT(mu_anc_alpha_t2);
+  // REPORT(mu_anc_rho_t2);
+  // REPORT(mu_anc_alpha_t2);
 
   REPORT(pR_i);
   REPORT(nu);

--- a/tests/testthat/test-model-fit.R
+++ b/tests/testthat/test-model-fit.R
@@ -29,3 +29,29 @@ test_that("exceeding maximum iterations throws a warning", {
                  "iteration limit reached")
 })
 
+test_that("model fits with differing number of ANC observations T1 and T2", {
+
+  ancdat <- mwi_anc_testing %>%
+    dplyr::group_by(year) %>%
+    dplyr::filter(year == 2016 |
+                  year == 2018 & dplyr::row_number() == 1) %>%
+    dplyr::ungroup()
+  
+  naomi_data <- select_naomi_data(a_naomi_mf,
+                                  mwi_survey_hiv_indicators,
+                                  anc_testing = ancdat,
+                                  mwi_art_number,
+                                  prev_survey_ids = c("MWI2016PHIA", "MWI2015DHS"),
+                                  artcov_survey_ids = "MWI2016PHIA",
+                                  recent_survey_ids = "MWI2016PHIA",
+                                  anc_prev_year_t1 = 2016,
+                                  anc_prev_year_t2 = 2018,
+                                  anc_artcov_year_t1 = 2016,
+                                  anc_artcov_year_t2 = 2018)
+
+  tmb_inputs <- prepare_tmb_inputs(naomi_data)
+  a_fit <- fit_tmb(tmb_inputs, outer_verbose = FALSE)
+
+  expect_equal(a_fit$convergence, 0)
+  
+})


### PR DESCRIPTION
This PR simply comments out the offending code to for including time 2 ANC data in the model.

It includes a regression test for the issue.

Please review and deploy this if it passes to get tool working again. 

Fix for implementation coming later.