### PR TITLE
output ANC prevalence and ART coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.32
+Version: 0.0.33
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.31
+Version: 0.0.32
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # naomi 0.0.31
 
 * Implement ANC prevalence and ART coverage for all areas.
+* Add ANC prevalence and ART coverage to indicators outputs.  Note: currently this si implemented only for age 15-49 at the level of model fitting. This should enable comparisons with input data. Later this can be extended for higher level aggregations.
 
 # naomi 0.0.31
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # naomi 0.0.31
 
+* Implement ANC prevalence and ART coverage for all areas.
+
+# naomi 0.0.31
+
 * Fix validation bug caused by missing programme options
 
 # naomi 0.0.30

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
-# naomi 0.0.32
-
-* Add receiving ART output indicator
-
-# naomi 0.0.31
+# naomi 0.0.33
 
 * Implement ANC prevalence and ART coverage for all areas.
 * Add ANC prevalence and ART coverage to indicators outputs.  Note: currently this si implemented only for age 15-49 at the level of model fitting. This should enable comparisons with input data. Later this can be extended for higher level aggregations.
+
+# naomi 0.0.32
+
+* Add receiving ART output indicator
 
 # naomi 0.0.31
 

--- a/R/model.R
+++ b/R/model.R
@@ -739,7 +739,6 @@ anc_testing_prev_mf <- function(year, anc_testing, naomi_mf) {
     ## No ANC prevalence data used
     anc_prev_dat <- data.frame(
       area_id = character(0),
-      anc_idx = integer(0),
       anc_prev_x = integer(0),
       anc_prev_n = integer(0),
       stringsAsFactors = FALSE
@@ -764,7 +763,6 @@ anc_testing_prev_mf <- function(year, anc_testing, naomi_mf) {
       dplyr::ungroup() %>%
       dplyr::transmute(
                area_id,
-               anc_idx = dplyr::row_number(),
                anc_prev_x = ancrt_known_pos + ancrt_test_pos,
                anc_prev_n = ancrt_known_pos + ancrt_tested
              )
@@ -773,7 +771,15 @@ anc_testing_prev_mf <- function(year, anc_testing, naomi_mf) {
       stop("ANC testing positive greater than anc testing total known status")
     
   }
-
+  
+  ## Add area index
+  anc_prev_dat <- anc_prev_dat %>%
+    dplyr::left_join(
+             dplyr::select(naomi_mf$mf_areas, area_id, area_idx),
+             by = "area_id"
+           ) %>%
+    dplyr::select(area_id, area_idx, anc_prev_x, anc_prev_n)
+  
   anc_prev_dat
 }
 
@@ -786,7 +792,6 @@ anc_testing_artcov_mf <- function(year, anc_testing, naomi_mf) {
     ## No ANC ART coverage data used
     anc_artcov_dat <- data.frame(
       area_id = character(0),
-      anc_idx = integer(0),
       anc_artcov_x = integer(0),
       anc_artcov_n = integer(0),
       stringsAsFactors = FALSE
@@ -812,7 +817,6 @@ anc_testing_artcov_mf <- function(year, anc_testing, naomi_mf) {
       dplyr::mutate(ancrt_totpos = ancrt_known_pos + ancrt_test_pos) %>%
       dplyr::transmute(
                area_id,
-               anc_idx = dplyr::row_number(),
                anc_artcov_x = ancrt_already_art,
                anc_artcov_n = ancrt_totpos
              )
@@ -821,6 +825,15 @@ anc_testing_artcov_mf <- function(year, anc_testing, naomi_mf) {
       stop("ANC testing on ART greater than anc testing total positive.")
 
   }
+
+  ## Add area index
+  anc_artcov_dat <- anc_artcov_dat %>%
+    dplyr::left_join(
+             dplyr::select(naomi_mf$mf_areas, area_id, area_idx),
+             by = "area_id"
+           ) %>%
+    dplyr::select(area_id, area_idx, anc_artcov_x, anc_artcov_n)
+
 
   anc_artcov_dat
 }

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -31,10 +31,8 @@ prepare_tmb_inputs <- function(naomi_data) {
     A
   }
 
-  A_anc_prev_t1 <- create_anc_Amat(naomi_data, "asfr", "population_t1")
-  A_anc_prev_t2 <- create_anc_Amat(naomi_data, "asfr", "population_t2")
-  A_anc_artcov_t1 <- create_anc_Amat(naomi_data, "asfr", "population_t1")
-  A_anc_artcov_t2 <- create_anc_Amat(naomi_data, "asfr", "population_t2")
+  A_anc_t1 <- create_anc_Amat(naomi_data, "asfr", "population_t1")
+  A_anc_t2 <- create_anc_Amat(naomi_data, "asfr", "population_t2")
 
   X_15to49 <- Matrix::t(Matrix::sparse.model.matrix(~-1 + area_idf:age15to49, naomi_data$mf_model))
 
@@ -83,6 +81,8 @@ prepare_tmb_inputs <- function(naomi_data) {
     ## Z_xa = Matrix::sparse.model.matrix(~0 + area_idf:age_group_idf, df),
     Z_ancrho_x = Matrix::sparse.model.matrix(~0 + area_idf, naomi_data$mf_areas),
     Z_ancalpha_x = Matrix::sparse.model.matrix(~0 + area_idf, naomi_data$mf_areas),
+    A_anc_t1 = A_anc_t1,
+    A_anc_t2 = A_anc_t2,
     ##
     logit_rho_offset = naomi_data$mf_model$logit_rho_offset,
     logit_alpha_offset = naomi_data$mf_model$logit_alpha_offset,
@@ -123,19 +123,15 @@ prepare_tmb_inputs <- function(naomi_data) {
     x_recent = naomi_data$recent_dat$x,
     n_recent = naomi_data$recent_dat$n,
     ##
-    A_anc_prev_t1 = A_anc_prev_t1,
     idx_anc_prev_t1 = naomi_data$anc_prev_t1_dat$area_idx - 1L,
     x_anc_prev_t1 = naomi_data$anc_prev_t1_dat$anc_prev_x,
     n_anc_prev_t1 = naomi_data$anc_prev_t1_dat$anc_prev_n,
-    A_anc_artcov_t1 = A_anc_artcov_t1,
     idx_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$area_idx - 1L,
     x_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$anc_artcov_x,
     n_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$anc_artcov_n,
-    A_anc_prev_t2 = A_anc_prev_t2,
     idx_anc_prev_t2 = naomi_data$anc_prev_t2_dat$area_idx - 1L,
     x_anc_prev_t2 = naomi_data$anc_prev_t2_dat$anc_prev_x,
     n_anc_prev_t2 = naomi_data$anc_prev_t2_dat$anc_prev_n,
-    A_anc_artcov_t2 = A_anc_artcov_t2,
     idx_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$area_idx - 1L,
     x_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$anc_artcov_x,
     n_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$anc_artcov_n,

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -11,48 +11,19 @@ prepare_tmb_inputs <- function(naomi_data) {
   stopifnot(is(naomi_data, "naomi_data"))
   stopifnot(is(naomi_data, "naomi_mf"))
 
-  ## ANC prevalence model matrices
-  anc_prev_t1_dat <- naomi_data$anc_prev_t1_dat %>%
-    dplyr::left_join(
-             naomi_data$mf_areas,
-             by = "area_id"
-           )
+  create_anc_Amat <- function(naomi_mf, asfr_col, population_col) {
 
-  anc_artcov_t1_dat <- naomi_data$anc_artcov_t1_dat %>%
-    dplyr::left_join(
-             naomi_data$mf_areas,
-             by = "area_id"
-           )
-
-  anc_prev_t2_dat <- naomi_data$anc_prev_t2_dat %>%
-    dplyr::left_join(
-             naomi_data$mf_areas,
-             by = "area_id"
-           )
-
-  anc_artcov_t2_dat <- naomi_data$anc_artcov_t2_dat %>%
-    dplyr::left_join(
-             naomi_data$mf_areas,
-             by = "area_id"
-           )
-
-  create_anc_Amat <- function(dat, naomi_mf, asfr_col, population_col) {
-    A <- dat %>%
-      dplyr::inner_join(
-               naomi_data$mf_model,
-               by = "area_id"
-             ) %>%
+    A <- naomi_data$mf_model %>%
       dplyr::transmute(
                area_id,
-               anc_idx,
+               area_idx,
                idx,
                births = !!rlang::sym(asfr_col) * !!rlang::sym(population_col)
              ) %>%
-      dplyr::filter(births > 0) %>%
-    {
-      Matrix::spMatrix(nrow(dat),
+      {
+      Matrix::spMatrix(nrow(naomi_data$mf_areas),
                        nrow(naomi_data$mf_model),
-                       .$anc_idx,
+                       .$area_idx,
                        .$idx,
                        .$births)
     }
@@ -60,10 +31,10 @@ prepare_tmb_inputs <- function(naomi_data) {
     A
   }
 
-  A_anc_prev_t1 <- create_anc_Amat(anc_prev_t1_dat, naomi_data, "asfr", "population_t1")
-  A_anc_prev_t2 <- create_anc_Amat(anc_prev_t2_dat, naomi_data, "asfr", "population_t2")
-  A_anc_artcov_t1 <- create_anc_Amat(anc_artcov_t1_dat, naomi_data, "asfr", "population_t1")
-  A_anc_artcov_t2 <- create_anc_Amat(anc_artcov_t2_dat, naomi_data, "asfr", "population_t2")
+  A_anc_prev_t1 <- create_anc_Amat(naomi_data, "asfr", "population_t1")
+  A_anc_prev_t2 <- create_anc_Amat(naomi_data, "asfr", "population_t2")
+  A_anc_artcov_t1 <- create_anc_Amat(naomi_data, "asfr", "population_t1")
+  A_anc_artcov_t2 <- create_anc_Amat(naomi_data, "asfr", "population_t2")
 
   X_15to49 <- Matrix::t(Matrix::sparse.model.matrix(~-1 + area_idf:age15to49, naomi_data$mf_model))
 
@@ -101,8 +72,8 @@ prepare_tmb_inputs <- function(naomi_data) {
     X_alpha = stats::model.matrix(~as.integer(sex == "female"), df),
     X_alpha_t2 = stats::model.matrix(~1, df),
     X_lambda = stats::model.matrix(~as.integer(sex == "female"), df),
-    X_ancrho = stats::model.matrix(~1, anc_prev_t1_dat),
-    X_ancalpha = stats::model.matrix(~1, anc_artcov_t1_dat),
+    X_ancrho = stats::model.matrix(~1, naomi_data$mf_areas),
+    X_ancalpha = stats::model.matrix(~1, naomi_data$mf_areas),
     Z_x = Matrix::sparse.model.matrix(~0 + area_idf, df),
     Z_xs = Matrix::sparse.model.matrix(~0 + area_idf, df) * (df$sex == "female"),
     Z_rho_a = Matrix::sparse.model.matrix(f_rho_a, df),
@@ -110,8 +81,8 @@ prepare_tmb_inputs <- function(naomi_data) {
     Z_alpha_a = Matrix::sparse.model.matrix(f_alpha_a, df),
     Z_alpha_as = Matrix::sparse.model.matrix(f_alpha_a, df) * (df$sex == "female"),
     ## Z_xa = Matrix::sparse.model.matrix(~0 + area_idf:age_group_idf, df),
-    Z_ancrho_x = Matrix::sparse.model.matrix(~0 + area_idf, anc_prev_t1_dat),
-    Z_ancalpha_x = Matrix::sparse.model.matrix(~0 + area_idf, anc_artcov_t1_dat),
+    Z_ancrho_x = Matrix::sparse.model.matrix(~0 + area_idf, naomi_data$mf_areas),
+    Z_ancalpha_x = Matrix::sparse.model.matrix(~0 + area_idf, naomi_data$mf_areas),
     ##
     logit_rho_offset = naomi_data$mf_model$logit_rho_offset,
     logit_alpha_offset = naomi_data$mf_model$logit_alpha_offset,
@@ -153,17 +124,21 @@ prepare_tmb_inputs <- function(naomi_data) {
     n_recent = naomi_data$recent_dat$n,
     ##
     A_anc_prev_t1 = A_anc_prev_t1,
-    x_anc_prev_t1 = anc_prev_t1_dat$anc_prev_x,
-    n_anc_prev_t1 = anc_prev_t1_dat$anc_prev_n,
+    idx_anc_prev_t1 = naomi_data$anc_prev_t1_dat$area_idx - 1L,
+    x_anc_prev_t1 = naomi_data$anc_prev_t1_dat$anc_prev_x,
+    n_anc_prev_t1 = naomi_data$anc_prev_t1_dat$anc_prev_n,
     A_anc_artcov_t1 = A_anc_artcov_t1,
-    x_anc_artcov_t1 = anc_artcov_t1_dat$anc_artcov_x,
-    n_anc_artcov_t1 = anc_artcov_t1_dat$anc_artcov_n,
+    idx_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$area_idx - 1L,
+    x_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$anc_artcov_x,
+    n_anc_artcov_t1 = naomi_data$anc_artcov_t1_dat$anc_artcov_n,
     A_anc_prev_t2 = A_anc_prev_t2,
-    x_anc_prev_t2 = anc_prev_t2_dat$anc_prev_x,
-    n_anc_prev_t2 = anc_prev_t2_dat$anc_prev_n,
+    idx_anc_prev_t2 = naomi_data$anc_prev_t2_dat$area_idx - 1L,
+    x_anc_prev_t2 = naomi_data$anc_prev_t2_dat$anc_prev_x,
+    n_anc_prev_t2 = naomi_data$anc_prev_t2_dat$anc_prev_n,
     A_anc_artcov_t2 = A_anc_artcov_t2,
-    x_anc_artcov_t2 = anc_artcov_t2_dat$anc_artcov_x,
-    n_anc_artcov_t2 = anc_artcov_t2_dat$anc_artcov_n,
+    idx_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$area_idx - 1L,
+    x_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$anc_artcov_x,
+    n_anc_artcov_t2 = naomi_data$anc_artcov_t2_dat$anc_artcov_n,
     ##
     A_artattend_t1 = A_artattend_t1,
     x_artnum_t1 = naomi_data$artnum_t1_dat$current_art,

--- a/inst/metadata/colour_scales.csv
+++ b/inst/metadata/colour_scales.csv
@@ -10,6 +10,8 @@ default,plhiv,interpolateMagma,0,10000000,TRUE
 default,incidence,interpolateMagma,0,0.01,TRUE
 default,new_infections,interpolateMagma,0,40000,TRUE
 default,receiving_art,interpolateViridis,0,80000,FALSE
+default,anc_prevalence,interpolateMagma,0,0.5,TRUE
+default,anc_art_coverage,interpolateViridis,0,1,FALSE
 MWI,current_art,interpolateViridis,0,80000,FALSE
 MWI,prevalence,interpolateMagma,0,0.5,TRUE
 MWI,art_coverage,interpolateViridis,0,1,FALSE
@@ -21,3 +23,5 @@ MWI,plhiv,interpolateMagma,0,10000000,TRUE
 MWI,incidence,interpolateMagma,0,0.01,TRUE
 MWI,new_infections,interpolateMagma,0,40000,TRUE
 MWI,receiving_art,interpolateViridis,0,1,FALSE
+MWI,anc_prevalence,interpolateMagma,0,0.5,TRUE
+MWI,anc_art_coverage,interpolateViridis,0,1,FALSE

--- a/inst/metadata/metadata.csv
+++ b/inst/metadata/metadata.csv
@@ -14,6 +14,8 @@ output,choropleth,population,mean,,,indicator_id,1,Population
 output,choropleth,plhiv,mean,,,indicator_id,3,PLHIV
 output,choropleth,incidence,mean,,,indicator_id,7,HIV incidence
 output,choropleth,new_infections,mean,,,indicator_id,8,New infections
+output,choropleth,anc_prevalence,mean,lower,upper,indicator_id,9,ANC HIV prevalence
+output,choropleth,anc_art_coverage,mean,lower,upper,indicator_id,10,ANC prior ART coverage
 output,barchart,prevalence,mean,lower,upper,indicator_id,2,HIV prevalence
 output,barchart,art_coverage,mean,lower,upper,indicator_id,4,ART coverage
 output,barchart,current_art,mean,lower,upper,indicator_id,5,ART number
@@ -22,3 +24,5 @@ output,barchart,population,mean,lower,upper,indicator_id,1,Population
 output,barchart,plhiv,mean,lower,upper,indicator_id,3,PLHIV
 output,barchart,incidence,mean,lower,upper,indicator_id,7,HIV incidence
 output,barchart,new_infections,mean,lower,upper,indicator_id,8,New infections
+output,barchart,anc_prevalence,mean,lower,upper,indicator_id,9,ANC HIV prevalence
+output,barchart,anc_art_coverage,mean,lower,upper,indicator_id,10,ANC prior ART coverage

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -67,18 +67,23 @@ Type objective_function<Type>::operator() ()
   DATA_VECTOR(x_recent);
   
   DATA_SPARSE_MATRIX(A_anc_prev_t1);
+
+  DATA_IVECTOR(idx_anc_prev_t1);
   DATA_VECTOR(n_anc_prev_t1);
   DATA_VECTOR(x_anc_prev_t1);
 
   DATA_SPARSE_MATRIX(A_anc_artcov_t1);
+  DATA_IVECTOR(idx_anc_artcov_t1);
   DATA_VECTOR(n_anc_artcov_t1);
   DATA_VECTOR(x_anc_artcov_t1);
 
   DATA_SPARSE_MATRIX(A_anc_prev_t2);
+  DATA_IVECTOR(idx_anc_prev_t2);
   DATA_VECTOR(n_anc_prev_t2);
   DATA_VECTOR(x_anc_prev_t2);
 
   DATA_SPARSE_MATRIX(A_anc_artcov_t2);
+  DATA_IVECTOR(idx_anc_artcov_t2);
   DATA_VECTOR(n_anc_artcov_t2);
   DATA_VECTOR(x_anc_artcov_t2);
   
@@ -420,23 +425,32 @@ Type objective_function<Type>::operator() ()
   
   vector<Type> mu_anc_rho_t1(A_anc_prev_t1 * rho_t1 / (A_anc_prev_t1 * ones));
   mu_anc_rho_t1 = logit(mu_anc_rho_t1) + X_ancrho * beta_anc_rho + Z_ancrho_x * ui_anc_rho_x * sigma_ancrho_x;
-  val -= sum(dbinom_robust(x_anc_prev_t1, n_anc_prev_t1, mu_anc_rho_t1, true));
+  for(int i = 0; i < idx_anc_prev_t1.size(); i++)
+    val -= dbinom_robust(x_anc_prev_t1[i], n_anc_prev_t1[i],
+			 mu_anc_rho_t1[idx_anc_prev_t1[i]], true);
 
   vector<Type> mu_anc_alpha_t1(A_anc_artcov_t1 * vector<Type>(rho_t1 * alpha_t1) / (A_anc_artcov_t1 * rho_t1));
   mu_anc_alpha_t1 = logit(mu_anc_alpha_t1) + X_ancalpha * beta_anc_alpha + Z_ancalpha_x * ui_anc_alpha_x * sigma_ancalpha_x;
-  val -= sum(dbinom_robust(x_anc_artcov_t1, n_anc_artcov_t1, mu_anc_alpha_t1, true));
+  for(int i = 0; i < idx_anc_artcov_t1.size(); i++)
+    val -= dbinom_robust(x_anc_artcov_t1[i], n_anc_artcov_t1[i],
+			 mu_anc_rho_t1[idx_anc_artcov_t1[i]], true);
 
-  // vector<Type> mu_anc_rho_t2(A_anc_prev_t2 * rho_t2 / (A_anc_prev_t2 * ones));
-  // mu_anc_rho_t2 = logit(mu_anc_rho_t2) +
-  //   X_ancrho * vector<Type>(beta_anc_rho + beta_anc_rho_t2) +
-  //   Z_ancrho_x * vector<Type>(ui_anc_rho_x * sigma_ancrho_x + ui_anc_rho_xt * sigma_ancrho_xt);
-  // val -= sum(dbinom_robust(x_anc_prev_t2, n_anc_prev_t2, mu_anc_rho_t2, true));
 
-  // vector<Type> mu_anc_alpha_t2(A_anc_artcov_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_artcov_t2 * rho_t2));
-  // mu_anc_alpha_t2 = logit(mu_anc_alpha_t2) +
-  //   X_ancalpha * vector<Type>(beta_anc_alpha + beta_anc_alpha_t2) +
-  //   Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);
-  // val -= sum(dbinom_robust(x_anc_artcov_t2, n_anc_artcov_t2, mu_anc_alpha_t2, true));
+  vector<Type> mu_anc_rho_t2(A_anc_prev_t2 * rho_t2 / (A_anc_prev_t2 * ones));
+  mu_anc_rho_t2 = logit(mu_anc_rho_t2) +
+    X_ancrho * vector<Type>(beta_anc_rho + beta_anc_rho_t2) +
+    Z_ancrho_x * vector<Type>(ui_anc_rho_x * sigma_ancrho_x + ui_anc_rho_xt * sigma_ancrho_xt);
+  for(int i = 0; i < idx_anc_prev_t2.size(); i++)
+    val -= dbinom_robust(x_anc_prev_t2[i], n_anc_prev_t2[i],
+			 mu_anc_rho_t2[idx_anc_prev_t2[i]], true);
+  
+  vector<Type> mu_anc_alpha_t2(A_anc_artcov_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_artcov_t2 * rho_t2));
+  mu_anc_alpha_t2 = logit(mu_anc_alpha_t2) +
+    X_ancalpha * vector<Type>(beta_anc_alpha + beta_anc_alpha_t2) +
+    Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);
+  for(int i = 0; i < idx_anc_artcov_t2.size(); i++)
+    val -= dbinom_robust(x_anc_artcov_t2[i], n_anc_artcov_t2[i],
+			 mu_anc_rho_t2[idx_anc_artcov_t2[i]], true);
 
 
   // * ART attendance model *

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -516,6 +516,11 @@ Type objective_function<Type>::operator() ()
   vector<Type> infections_t2_out(A_out * infections_t2);
   vector<Type> lambda_t2_out(infections_t2_out / (population_t2_out - plhiv_t2_out));
 
+  vector<Type> anc_rho_t1_out(invlogit(mu_anc_rho_t1));
+  vector<Type> anc_rho_t2_out(invlogit(mu_anc_rho_t2));
+
+  vector<Type> anc_alpha_t1_out(invlogit(mu_anc_alpha_t1));
+  vector<Type> anc_alpha_t2_out(invlogit(mu_anc_alpha_t2));
   
   REPORT(plhiv_t1);
   REPORT(population_t1);
@@ -554,11 +559,10 @@ Type objective_function<Type>::operator() ()
   REPORT(infections_t2_out);
 
 
-  REPORT(mu_anc_rho_t1);
-  REPORT(mu_anc_alpha_t1);
-
-  // REPORT(mu_anc_rho_t2);
-  // REPORT(mu_anc_alpha_t2);
+  REPORT(anc_rho_t1_out);
+  REPORT(anc_alpha_t1_out);
+  REPORT(anc_rho_t2_out);
+  REPORT(anc_alpha_t2_out);
 
   REPORT(pR_i);
   REPORT(nu);

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -41,11 +41,15 @@ Type objective_function<Type>::operator() ()
   DATA_SPARSE_MATRIX(Z_alpha_a);
   DATA_SPARSE_MATRIX(Z_alpha_as);
 
-  DATA_VECTOR(logit_rho_offset)
-  DATA_VECTOR(logit_alpha_offset)
+  DATA_VECTOR(logit_rho_offset);
+  DATA_VECTOR(logit_alpha_offset);
+
+  DATA_SPARSE_MATRIX(A_anc_t1);
+  DATA_SPARSE_MATRIX(A_anc_t2);
 
   DATA_SPARSE_MATRIX(Z_ancrho_x);
   DATA_SPARSE_MATRIX(Z_ancalpha_x);
+
 
   // Precision matrix for ICAR area model
   DATA_SPARSE_MATRIX(Q_x);
@@ -66,23 +70,18 @@ Type objective_function<Type>::operator() ()
   DATA_VECTOR(n_recent);
   DATA_VECTOR(x_recent);
   
-  DATA_SPARSE_MATRIX(A_anc_prev_t1);
-
   DATA_IVECTOR(idx_anc_prev_t1);
   DATA_VECTOR(n_anc_prev_t1);
   DATA_VECTOR(x_anc_prev_t1);
 
-  DATA_SPARSE_MATRIX(A_anc_artcov_t1);
   DATA_IVECTOR(idx_anc_artcov_t1);
   DATA_VECTOR(n_anc_artcov_t1);
   DATA_VECTOR(x_anc_artcov_t1);
 
-  DATA_SPARSE_MATRIX(A_anc_prev_t2);
   DATA_IVECTOR(idx_anc_prev_t2);
   DATA_VECTOR(n_anc_prev_t2);
   DATA_VECTOR(x_anc_prev_t2);
 
-  DATA_SPARSE_MATRIX(A_anc_artcov_t2);
   DATA_IVECTOR(idx_anc_artcov_t2);
   DATA_VECTOR(n_anc_artcov_t2);
   DATA_VECTOR(x_anc_artcov_t2);
@@ -423,20 +422,20 @@ Type objective_function<Type>::operator() ()
     val -= dbinom(x_recent[i], n_recent[i], pR, true);
   }
   
-  vector<Type> mu_anc_rho_t1(A_anc_prev_t1 * rho_t1 / (A_anc_prev_t1 * ones));
+  vector<Type> mu_anc_rho_t1(A_anc_t1 * rho_t1 / (A_anc_t1 * ones));
   mu_anc_rho_t1 = logit(mu_anc_rho_t1) + X_ancrho * beta_anc_rho + Z_ancrho_x * ui_anc_rho_x * sigma_ancrho_x;
   for(int i = 0; i < idx_anc_prev_t1.size(); i++)
     val -= dbinom_robust(x_anc_prev_t1[i], n_anc_prev_t1[i],
 			 mu_anc_rho_t1[idx_anc_prev_t1[i]], true);
 
-  vector<Type> mu_anc_alpha_t1(A_anc_artcov_t1 * vector<Type>(rho_t1 * alpha_t1) / (A_anc_artcov_t1 * rho_t1));
+  vector<Type> mu_anc_alpha_t1(A_anc_t1 * vector<Type>(rho_t1 * alpha_t1) / (A_anc_t1 * rho_t1));
   mu_anc_alpha_t1 = logit(mu_anc_alpha_t1) + X_ancalpha * beta_anc_alpha + Z_ancalpha_x * ui_anc_alpha_x * sigma_ancalpha_x;
   for(int i = 0; i < idx_anc_artcov_t1.size(); i++)
     val -= dbinom_robust(x_anc_artcov_t1[i], n_anc_artcov_t1[i],
 			 mu_anc_rho_t1[idx_anc_artcov_t1[i]], true);
 
 
-  vector<Type> mu_anc_rho_t2(A_anc_prev_t2 * rho_t2 / (A_anc_prev_t2 * ones));
+  vector<Type> mu_anc_rho_t2(A_anc_t2 * rho_t2 / (A_anc_t2 * ones));
   mu_anc_rho_t2 = logit(mu_anc_rho_t2) +
     X_ancrho * vector<Type>(beta_anc_rho + beta_anc_rho_t2) +
     Z_ancrho_x * vector<Type>(ui_anc_rho_x * sigma_ancrho_x + ui_anc_rho_xt * sigma_ancrho_xt);
@@ -444,7 +443,7 @@ Type objective_function<Type>::operator() ()
     val -= dbinom_robust(x_anc_prev_t2[i], n_anc_prev_t2[i],
 			 mu_anc_rho_t2[idx_anc_prev_t2[i]], true);
   
-  vector<Type> mu_anc_alpha_t2(A_anc_artcov_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_artcov_t2 * rho_t2));
+  vector<Type> mu_anc_alpha_t2(A_anc_t2 * vector<Type>(rho_t2 * alpha_t2) / (A_anc_t2 * rho_t2));
   mu_anc_alpha_t2 = logit(mu_anc_alpha_t2) +
     X_ancalpha * vector<Type>(beta_anc_alpha + beta_anc_alpha_t2) +
     Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -432,7 +432,7 @@ Type objective_function<Type>::operator() ()
   mu_anc_alpha_t1 = logit(mu_anc_alpha_t1) + X_ancalpha * beta_anc_alpha + Z_ancalpha_x * ui_anc_alpha_x * sigma_ancalpha_x;
   for(int i = 0; i < idx_anc_artcov_t1.size(); i++)
     val -= dbinom_robust(x_anc_artcov_t1[i], n_anc_artcov_t1[i],
-			 mu_anc_rho_t1[idx_anc_artcov_t1[i]], true);
+			 mu_anc_alpha_t1[idx_anc_artcov_t1[i]], true);
 
 
   vector<Type> mu_anc_rho_t2(A_anc_t2 * rho_t2 / (A_anc_t2 * ones));
@@ -449,7 +449,7 @@ Type objective_function<Type>::operator() ()
     Z_ancalpha_x * vector<Type>(ui_anc_alpha_x * sigma_ancalpha_x + ui_anc_alpha_xt * sigma_ancalpha_xt);
   for(int i = 0; i < idx_anc_artcov_t2.size(); i++)
     val -= dbinom_robust(x_anc_artcov_t2[i], n_anc_artcov_t2[i],
-			 mu_anc_rho_t2[idx_anc_artcov_t2[i]], true);
+			 mu_anc_alpha_t2[idx_anc_artcov_t2[i]], true);
 
 
   // * ART attendance model *

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -42,7 +42,8 @@ test_that("can get plot metadata for a country", {
                   c("art_coverage", "current_art", "receiving_art",
                     "prevalence", "art_number",
                     "incidence", "new_infections", "plhiv", "population",
-                    "recent", "vls")))
+                    "recent", "vls",
+                    "anc_prevalence", "anc_art_coverage")))
 })
 
 test_that("can get plot metadata for missing country with defaults", {
@@ -58,14 +59,16 @@ test_that("can get plot metadata for missing country with defaults", {
                   c("art_coverage", "current_art", "receiving_art",
                     "prevalence", "art_number",
                     "incidence", "new_infections", "plhiv", "population",
-                    "recent", "vls")))
+                    "recent", "vls",
+                    "anc_prevalence", "anc_art_coverage")))
 })
 
 test_that("colour scales metadata is well formed", {
   scales <- naomi_read_csv(system_file("metadata", "colour_scales.csv"))
   expect_true(all(scales$indicator %in%
     c("art_coverage", "current_art", "receiving_art", "prevalence", "vls", "recent",
-      "art_number", "plhiv", "incidence", "population", "new_infections")))
+      "art_number", "plhiv", "incidence", "population", "new_infections",
+      "anc_prevalence", "anc_art_coverage")))
   expect_equal(nrow(unique(scales[, c("iso3", "indicator")])), nrow(scales))
   expect_true(is.numeric(scales$min))
   expect_true(is.numeric(scales$max))
@@ -88,7 +91,7 @@ test_that("metadata is well formed", {
   expect_true(all(meta$indicator %in%
     c("art_coverage", "current_art", "prevalence", "vls", "recent", "plhiv",
       "incidence", "art_number", "population", "incidence", "new_infections",
-      "receiving_art")))
+      "receiving_art", "anc_prevalence", "anc_art_coverage")))
   expect_equal(nrow(unique(meta[, c("data_type", "plot_type", "indicator")])),
                nrow(meta))
   expect_true(all(meta$plot_type %in% c("choropleth", "barchart")))
@@ -97,7 +100,8 @@ test_that("metadata is well formed", {
                     c("HIV prevalence", "ART coverage", "Viral load suppression",
                       "Proportion recently infected", "PLHIV", "Population",
                       "New infections", "HIV incidence", "ART number",
-                      "Receiving ART")))
+                      "Receiving ART", "ANC HIV prevalence",
+                      "ANC prior ART coverage")))
   ## No NULLs, NAs or empty strings except for indicator_column and
   ## indicator_value columns
   non_empty_columns <- colnames(

--- a/tests/testthat/test-model-fit.R
+++ b/tests/testthat/test-model-fit.R
@@ -32,9 +32,10 @@ test_that("exceeding maximum iterations throws a warning", {
 test_that("model fits with differing number of ANC observations T1 and T2", {
 
   ancdat <- mwi_anc_testing %>%
+    filter(area_id %in% a_naomi_mf$mf_areas$area_id) %>%
     dplyr::group_by(year) %>%
     dplyr::filter(year == 2016 |
-                  year == 2018 & dplyr::row_number() == 1) %>%
+                  year == 2018 & dplyr::row_number() == 3) %>%
     dplyr::ungroup()
   
   naomi_data <- select_naomi_data(a_naomi_mf,
@@ -50,8 +51,8 @@ test_that("model fits with differing number of ANC observations T1 and T2", {
                                   anc_artcov_year_t2 = 2018)
 
   tmb_inputs <- prepare_tmb_inputs(naomi_data)
-  a_fit <- fit_tmb(tmb_inputs, outer_verbose = FALSE)
+  fit <- fit_tmb(tmb_inputs, outer_verbose = FALSE)
 
-  expect_equal(a_fit$convergence, 0)
+  expect_equal(fit$convergence, 0)
   
 })

--- a/tests/testthat/test-model-fit.R
+++ b/tests/testthat/test-model-fit.R
@@ -32,7 +32,7 @@ test_that("exceeding maximum iterations throws a warning", {
 test_that("model fits with differing number of ANC observations T1 and T2", {
 
   ancdat <- mwi_anc_testing %>%
-    filter(area_id %in% a_naomi_mf$mf_areas$area_id) %>%
+    dplyr::filter(area_id %in% a_naomi_mf$mf_areas$area_id) %>%
     dplyr::group_by(year) %>%
     dplyr::filter(year == 2016 |
                   year == 2018 & dplyr::row_number() == 3) %>%

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -20,7 +20,7 @@ test_that("model can be run", {
                  "calendar_quarter", "quarter_id", "quarter_label",
                  "indicator", "indicator_id", "indicator_label",
                  "mean", "se", "median", "mode", "lower", "upper"))
-  expect_true(nrow(output) == 30624)
+  expect_true(nrow(output) == 30624 + 40)
   expect_equal(model_run$spectrum_path, output_spectrum)
   file_list <- unzip(model_run$spectrum_path, list = TRUE)
   ## Note that this test is likely quite platform specific
@@ -101,7 +101,7 @@ test_that("model can be run without programme data", {
                  "calendar_quarter", "quarter_id", "quarter_label",
                  "indicator", "indicator_id", "indicator_label",
                  "mean", "se", "median", "mode", "lower", "upper"))
-  expect_true(nrow(output) == 30624)
+  expect_true(nrow(output) == 30624 + 2*2*10)
 
   expect_equal(model_run$spectrum_path, output_spectrum)
   file_list <- unzip(model_run$spectrum_path, list = TRUE)


### PR DESCRIPTION
* Reimplement properly the feature that we unwound in d948d50.
* Add ANC prevalence and ANC testing coverage as output indicators in indicators.csv.

Currently ANC prevalence and AND testing coverage outputs are only produced for all pregnant women ages at the level of model estimation. This will facilitate comparison of model outputs with input data. Other aggregates can be added later if there is demand.

The additional indicators are added to `metadata.csv` and `colourscales.csv`.  Please test with hints and UI before merging.

