### PR TITLE
fix error in time-varying ART attendance option from 0.0.64

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.64
+Version: 0.0.65
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 0.0.65
+
+* Fix error in default option for time-varying ART attendance model option in 0.0.64 release.
+
 # naomi 0.0.64
 
 * Area random effect for prevalence below age 15 interaction as ICAR model. Implemented as option `rho_paed_x_term` specified by argument `naomi_model_frame(..., rho_paed_x_term = TRUE, ...)`. Defaualt value is `FALSE`.

--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -340,7 +340,7 @@
 					"required": true,
 					"options": [
 						{
-							"id": "true",
+							"id": "false",
 							"label": "t_(OPTIONS_NO_LABEL)"
 						},
 						{
@@ -348,7 +348,7 @@
 							"label": "t_(OPTIONS_YES_LABEL)"
 						}
 					],
-					"value": "false",
+					"value": "true",
 					"helpText": "t_(OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP)"
 				}
 			]


### PR DESCRIPTION
There was an error in the advanced options JSON in 0.0.64 yesterday.  For the `artattend_t2` option, I changed the option value `false` to `true` instead of changing the default value from `false` to `true`.

The right value `true` is being passed by the model, but it displays incorrectly as "No" and there is no way to select `false` / "Yes", so a bit urgent.

For future test -- tests on the JSON options that (1) all options are unique and (2) the provided default option is contained in the options set would have caught this.  I suggest a separate ticket for those.

Sorry...

Thanks,
Jeff