### PR TITLE
mrc-1470: buildkite support for naomi

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^vignettes/model-workflow_cache$
 ^tests/testthat/testdata/fit.RDS$
 ^docker$
+^buildkite$

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
   # This triggers on every hint build so that we can check that the
   # changes work with hintr, and pass the naomi sha through an
   # environment variable.  The build is against hintr master
-  - trigger: "orderly-dot-server"
+  - trigger: "hintr"
     label: ":rocket: hintr (from naomi) :docker:"
     build:
       # branch: master # TODO <- set this one back once hintr merged

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,28 @@
+steps:
+  - label: ":whale: Build"
+    command: docker/build
+
+  - wait
+
+  - label: ":hammer: Test"
+    command: docker/test
+
+  - wait
+
+  - label: ":shipit: Push images"
+    command: docker/push
+
+  - wait
+
+  # The next step triggers a build on the hintr:
+  # https://buildkite.com/docs/pipelines/trigger-step
+  #
+  # This triggers on every hint build so that we can check that the
+  # changes work with hintr, and pass the naomi sha through an
+  # environment variable.  The build is against hintr master
+  - trigger: "orderly-dot-server"
+    label: ":rocket: hintr (from naomi) :docker:"
+    build:
+      branch: master
+      env:
+        NAOMI_SHA: "${BUILDKITE_COMMIT}"

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
   - trigger: "orderly-dot-server"
     label: ":rocket: hintr (from naomi) :docker:"
     build:
-      branch: master
+      # branch: master # TODO <- set this one back once hintr merged
+      branch: mrc-1471
       env:
         NAOMI_SHA: "${BUILDKITE_COMMIT}"

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -2,6 +2,21 @@ steps:
   - label: ":whale: Build"
     command: docker/build
 
+  # The next step triggers a build on the hintr:
+  # https://buildkite.com/docs/pipelines/trigger-step
+  #
+  # This triggers on every hint build so that we can check that the
+  # changes work with hintr, and pass the naomi sha through an
+  # environment variable.  The build is against hintr master
+  - trigger: "hintr"
+    label: ":rocket: hintr (from naomi) :docker:"
+    async: true
+    build:
+      # branch: master # TODO <- set this one back once hintr merged
+      branch: mrc-1471
+      env:
+        NAOMI_SHA: "${BUILDKITE_COMMIT}"
+
   - wait
 
   - label: ":hammer: Test"
@@ -13,17 +28,3 @@ steps:
     command: docker/push
 
   - wait
-
-  # The next step triggers a build on the hintr:
-  # https://buildkite.com/docs/pipelines/trigger-step
-  #
-  # This triggers on every hint build so that we can check that the
-  # changes work with hintr, and pass the naomi sha through an
-  # environment variable.  The build is against hintr master
-  - trigger: "hintr"
-    label: ":rocket: hintr (from naomi) :docker:"
-    build:
-      # branch: master # TODO <- set this one back once hintr merged
-      branch: mrc-1471
-      env:
-        NAOMI_SHA: "${BUILDKITE_COMMIT}"

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     async: true
     build:
       # branch: master # TODO <- set this one back once hintr merged
-      branch: mrc-1471
+      branch: master
       env:
         NAOMI_SHA: "${BUILDKITE_COMMIT}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,4 +64,11 @@ RUN install_packages remotes && install_remote \
     mrc-ide/eppasm \
     reside-ic/traduire
 
+ARG GIT_SHA='UNKNOWN'
+ARG GIT_BRANCH='UNKNOWN'
+ARG NAOMI_VERSION='UNKNOWN'
+ENV NAOMI_GIT_HASH $GIT_SHA
+ENV NAOMI_GIT_BRANCH $GIT_BRANCH
+ENV NAOMI_VERSION $NAOMI_VERSION
+
 COPY . /src

--- a/docker/build
+++ b/docker/build
@@ -4,9 +4,10 @@ HERE=$(dirname $0)
 . $HERE/common
 
 docker build --pull \
+       --build-arg GIT_SHA=$GIT_SHA \
+       --build-arg GIT_BRANCH=$GIT_BRANCH \
+       --build-arg NAOMI_VERSION=$PACKAGE_VERSION \
        -t $TAG_SHA \
-       -t $TAG_BRANCH \
-       -t $TAG_VERSION \
        -f docker/Dockerfile \
        .
 

--- a/docker/common
+++ b/docker/common
@@ -2,17 +2,27 @@
 PACKAGE_ROOT=$(realpath $HERE/..)
 PACKAGE_NAME=naomi
 PACKAGE_ORG=mrcide
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Version:' | \sed 's/^.*: *//')
 
-GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
-PKG_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | grep '^Version:' | sed 's/^.*: *//')
+# Buildkite doesn't check out a full history from the remote (just the
+# single commit) so you end up with a detached head and git rev-parse
+# doesn't work
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_SHA=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
+fi
 
 if [ "$TRAVIS" = "true" ]; then
     GIT_BRANCH=$TRAVIS_BRANCH
+elif [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
 else
     GIT_BRANCH=$(git -C "$PACKAGE_ROOT" symbolic-ref --short HEAD)
 fi
 
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
-TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PKG_VERSION}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PACKAGE_VERSION}"
 TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"

--- a/docker/push
+++ b/docker/push
@@ -3,12 +3,15 @@ set -e
 HERE=$(dirname $0)
 . $HERE/common
 
-# Push the human-readable tagged versions here (the SHA versions were
-# pushed during build)
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
+docker tag $TAG_SHA $TAG_BRANCH
 docker push $TAG_BRANCH
-docker push $TAG_VERSION
 
 if [ $GIT_BRANCH == "master" ]; then
-   docker tag $TAG_BRANCH $TAG_LATEST
+   docker tag $TAG_SHA $TAG_LATEST
+   docker tag $TAG_SHA $TAG_VERSION
    docker push $TAG_LATEST
+   docker push $TAG_VERSION
 fi

--- a/docker/teamcity
+++ b/docker/teamcity
@@ -3,4 +3,4 @@ set -e
 HERE=$(dirname $0)
 $HERE/build
 $HERE/test
-$HERE/push
+#$HERE/push

--- a/docker/test
+++ b/docker/test
@@ -3,4 +3,7 @@ set -e
 HERE=$(dirname $0)
 . $HERE/common
 
+# In case we switch agents between steps
+[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+
 docker run --rm $TAG_SHA test_self


### PR DESCRIPTION
This is the companion PR to https://github.com/mrc-ide/hintr/pull/179 and adds buildkite support to naomi.

The triggered build is currently done _after_ a successful naomi build/test/push but it's not clear that this is totally required as we could run this in parallel.  So we could do this as step 2, with no `wait` and add `async: true` so that it does not block the rest of the pipeline.  This might faster.