### PR TITLE
purpose save_result_summary() to save an output package with coarse age groups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 0.0.69
+Version: 0.0.70
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naomi 0.0.70
+
+* Use summary output download function to download a Naomi output package with 
+  coarse age groups only: 15-49, 15-64, 15+, 50+, 00+, 00-64, 00-14, 15-24, 
+  25-34, 35-49, 50-64, 65+.
+
 # naomi 0.0.69 
 
 * Add functions `subset_output_package()` to subset and re-save a zipped Naomi output package.

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -590,7 +590,12 @@ save_output_package <- function(naomi_output,
 }
 
 save_result_summary <- function(path, naomi_output) {
-  save_output(basename(path), dirname(path), naomi_output, overwrite = FALSE,
+
+  age_groups_keep <- c("15-49", "15-64", "15+", "50+", "00+", "00-64",
+                       "00-14", "15-24", "25-34", "35-49", "50-64", "65+")
+  naomi_output_sub <- subset_naomi_output(naomi_output, age_group = age_groups_keep)
+  
+  save_output(basename(path), dirname(path), naomi_output_sub, overwrite = FALSE,
               with_labels = TRUE, boundary_format = "geojson",
               single_csv = FALSE)
 }

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -71,6 +71,12 @@ test_that("model can be run", {
       names(output_boundaries))
   )
 
+  ## Check coarse age outputs saved in summar_path
+  coarse_ages <- c("15-49", "15-64", "15+", "50+", "00+", "00-64", "00-14",
+                   "15-24", "25-34", "35-49", "50-64", "65+")
+  coarse_age_outputs <- read_output_package(model_run$summary_path)
+  expect_setequal(coarse_age_outputs$meta_age_group$age_group, coarse_ages)
+  expect_setequal(coarse_age_outputs$indicators$age_group, coarse_ages)
 
   expect_equal(model_run$metadata$areas, "MWI_1_2")
 })


### PR DESCRIPTION
This updates the function `save_result_summary()` to save output package with only the age group 15-49, 15-64, 15+, 50+, 00+, 00-64, 00-14, 15-24, 25-34, 35-49, 50-64, 65+.

* Output package with fewer age groups tested in `test-run-model.R` to confirm that expected fewer age groups apper.
* Version number bumped to 0.0.70
* NEWS item added