### PR TITLE
patch sample_tmb() for R 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Additional_repositories:
     https://mrc-ide.github.io/drat
 Imports: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 1.0.2
+
+* Patch to `sample_tmb()` for R 4.0 changes.
+
 # naomi 1.0.0
 
 * Move tmbstan and INLA models to naomi.extensions repo as they add heavyweight 

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -518,8 +518,11 @@ sample_tmb <- function(fit, nsample = 1000, rng_seed = NULL,
 
   if(verbose) print("Returning sample")
   fit$sample <- Map(vapply, list(sim), "[[", lapply(lengths(r), numeric), names(r))
-  is_vector <- vapply(fit$sample, class, character(1)) == "numeric"
-  fit$sample[is_vector] <- lapply(fit$sample[is_vector], as.matrix, nrow = 1)
+
+  is_vector <- lapply(fit$sample, class)
+  is_vector <- vapply(is_vector, "[", character(1), 1) == "numeric"
+
+  fit$sample[is_vector] <- lapply(fit$sample[is_vector], matrix, nrow = 1)
   names(fit$sample) <- names(r)
 
   fit

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -518,9 +518,7 @@ sample_tmb <- function(fit, nsample = 1000, rng_seed = NULL,
 
   if(verbose) print("Returning sample")
   fit$sample <- Map(vapply, list(sim), "[[", lapply(lengths(r), numeric), names(r))
-
-  is_vector <- lapply(fit$sample, class)
-  is_vector <- vapply(is_vector, "[", character(1), 1) == "numeric"
+  is_vector <- vapply(fit$sample, inherits, logical(1), "numeric")
 
   fit$sample[is_vector] <- lapply(fit$sample[is_vector], matrix, nrow = 1)
   names(fit$sample) <- names(r)

--- a/man/scale_gmrf_precision.Rd
+++ b/man/scale_gmrf_precision.Rd
@@ -23,6 +23,6 @@ This function scales the precision matrix of a GMRF such that the geometric
 mean of the marginal variance is one.
 }
 \details{
-This implements the same thing as \code{\link[INLA:inla.scale.model]{INLA::inla.scale.model}}. The marginal
+This implements the same thing as \code{\link[INLA:scale.model]{INLA::inla.scale.model}}. The marginal
 variance of each connected component is one.
 }


### PR DESCRIPTION
[R 4.0 changes](https://cran.r-project.org/doc/manuals/r-release/NEWS.html) that matrix objects also now inherit class `"array"`:

>  * matrix objects now also inherit from class "array", so e.g., class(diag(1)) is c("matrix", "array"). This invalidates code incorrectly assuming that class(matrix_obj)) has length one.

This breaks [this line](https://github.com/mrc-ide/naomi/blob/b7ecd509108ec19dd3bb25f8127b214559942e1e/R/tmb-model.R#L521) in `sample_tmb()`, which assumes class has length one: 
```
  is_vector <- vapply(fit$sample, class, character(1)) == "numeric"
```

Fix this by using `inherits(x, "numeric")` function to check if class is `"numeric"`.

Also fix that coercion should use `matrix()` rather than `as.matrix()`.

Thanks,
Jeff
