### PR TITLE
remove age_group_id from summary_report.Rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 1.0.10
+
+* Edit `summary_report.Rmd` to remove `age_group_id`.
+
 # naomi 1.0.9
 
 * Add summary_report_path to model run for saving summary report

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -272,9 +272,9 @@ age_sex <- indicators %>% sf::st_drop_geometry()%>%
   dplyr::filter(area_level == area_filter,
                 calendar_quarter == quarter,
                 sex != "both",
-                age_group_id %in% 0:17) %>% #change range for different disags
+                age_group %in% get_five_year_age_groups()) %>%
   dplyr::left_join(naomi::get_age_groups()) %>%
-  dplyr::mutate(age_group = forcats::fct_reorder(age_group_label, age_group_id),
+  dplyr::mutate(age_group = forcats::fct_reorder(age_group_label, age_group_sort_order),
                 sex = factor(sex, levels = c("male", "female")) )
 
 


### PR DESCRIPTION
`age_group_id` was deprecated in favour of human readable `age_group` and `age_group_id` is being removed in Naomi 2.0.