### PR TITLE
patch summary report for case where area_name not unique

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.0.2
+
+* Patch to `inst/report/summary_report.Rmd` to handle error if `area_name` is not unique.
+
 # naomi 2.0.1
 
 * Remove calibration options from model run options

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -629,9 +629,9 @@ x3 <- x2  %>% dplyr::mutate(val = ifelse(indicator %in% percent_indicators,
                                          paste0(mean," (",lower,"-",upper,")")),)
 # Melt data in table 
 x4 <- x3 %>% 
-  dplyr::select(area_name, val, indicator) %>%
+  dplyr::select(area_id, area_name, val, indicator) %>%
   tidyr::spread(indicator, val) %>%
-  dplyr::select(area_name, plhiv, prevalence, infections, incidence,
+  dplyr::select(area_id, area_name, plhiv, prevalence, infections, incidence,
                 art_coverage, art_current_residents,
                 art_current)
 
@@ -641,7 +641,9 @@ x4 <- x3 %>%
 # # # By lowest area_level, indicators defined above
 # #------------------------------------------------------------------------------
 
-x4 %>% gt::gt(rowname_col = "area_name") %>%
+x4 %>%
+  dplyr::select(-area_id) %>%
+  gt::gt(rowname_col = "area_name") %>%
   gt::tab_stubhead(label = gt::md("**Area**")) %>%
   gt::tab_options(
     table.align = "left",


### PR DESCRIPTION
Generating the table in the summary report includes an argument `spread(indicator, val)`, where `area_name` is the remaining column as the ID column. The `area_name` is not guaranteed to be unique, and so this will not work.  The `area_id` is guaranteed to be unique and should always be used when manipulating, merging, or filtering data.

I haven't made any edit to the table, so there's an issue that the rows will not be distinguishable if the area name is duplicated. We need to think more about this.

If we are happy staying with an HTML formatted report, one elegant way to handle this might be to add a tool tip showing the full area hierarchy path.

Thanks,
Jeff