### PR TITLE
Update the default projection quarter to September 2021 from September 2020

### DIFF
--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -40,7 +40,7 @@
         {
           "name": "calendar_quarter_t3",
           "type": "select",
-          "value": "CY2020Q3",
+          "value": "CY2021Q3",
           "helpText": "t_(OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP)",
                  "required": true,
                 "options": [


### PR DESCRIPTION
On the Model Options page in the Output section, update the default projection quarter to September 2021 from September 2020.