### PR TITLE
mrc-1969 Makes advanced model options collapsed by default

### DIFF
--- a/inst/metadata/advanced_run_options.json
+++ b/inst/metadata/advanced_run_options.json
@@ -33,6 +33,8 @@
 {
   "label": "t_(OPTIONS_ADVANCED_LABEL)",
   "description": "t_(OPTIONS_ADVANCED_DESCRIPTION)",
+  "collapsible": true,
+  "collapsed": true,
   "controlGroups": [
     {
       "label": "t_(OPTIONS_ADVANCED_MAX_ITERATIONS_LABEL)",


### PR DESCRIPTION
This will cause the Advanced section in the model options to be collapsed by default. Most users do not use this section so having it collapsed to begin with helps to declutter the page. We might also want to make all sections collapsible. The potential downside is that it might cause the user to lose track of some of the options they had collapsed.