### PR TITLE
Make running validation of inputs optional in model run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.1.1
+Version: 2.1.2
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export("%>%")
 export(add_output_labels)
 export(anc_testing_artcov_mf)
+export(anc_testing_clients_mf)
 export(anc_testing_prev_mf)
 export(artnum_mf)
 export(calculate_prevalence_art_coverage)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.1.2
+
+* Make running input validation during model run optional
+
 # naomi 2.1.1
 
 * Make 'Advanced Options' panel on model options page collapsible by default

--- a/R/read-data.R
+++ b/R/read-data.R
@@ -1,14 +1,14 @@
 #' Read Naomi structured input files
 #'
 #' @param file A path to a file.
-#' 
+#'
 #' @export
 read_population <- function(file) {
 
   ## !! TODO: add file format asserts
 
   required_cols <- c("area_id", "calendar_quarter", "sex", "age_group", "population")
-  
+
   col_spec <- readr::cols_only(
                        area_id = readr::col_character(),
                        source = readr::col_character(),
@@ -25,8 +25,10 @@ read_population <- function(file) {
   val <- drop_na_rows(val)
 
   missing_cols <- setdiff(required_cols, names(val))
-  if(length(missing_cols))
-    stop(paste0("Required columns not found: ", paste(missing_cols, collapse = ", ")))
+  if(length(missing_cols)) {
+    stop(t_("POPULATION_REQUIRED_COLUMNS_MISSING",
+            list(cols = paste(missing_cols, collapse = ", "))))
+  }
 
   ## !! TODO: add validation asserts -- probably pull in hintr validation_asserts.R
 
@@ -42,7 +44,7 @@ read_survey_indicators <- function(file) {
   required_cols <- c("indicator", "survey_id", "area_id", "sex", "age_group",
                      "n_clusters", "n_observations", "n_eff_kish",
                      "estimate", "std_error", "ci_lower", "ci_upper")
-  
+
   col_spec <- readr::cols_only(
                        indicator = readr::col_character(),
                        survey_id = readr::col_character(),
@@ -59,12 +61,12 @@ read_survey_indicators <- function(file) {
                        ci_lower = readr::col_double(),
                        ci_upper = readr::col_double()
                      )
-  
+
   val <- read_csv_partial_cols(file, col_types = col_spec)
   readr::stop_for_problems(val)
 
   val <- drop_na_rows(val)
-  
+
   missing_cols <- setdiff(required_cols, names(val))
   if(length(missing_cols))
     stop(paste0("Required columns not found: ", paste(missing_cols, collapse = ", ")))
@@ -83,7 +85,7 @@ read_art_number <- function(file) {
   ## !! TODO: add file format asserts
 
   required_cols <- c("area_id", "sex", "age_group", "art_current")
-  
+
   col_spec <- readr::cols_only(
                        area_id = readr::col_character(),
                        sex = readr::col_character(),
@@ -93,7 +95,7 @@ read_art_number <- function(file) {
                        art_current = readr::col_double(),
                        art_new = readr::col_double()
                      )
-  
+
   val <- read_csv_partial_cols(file, col_types = col_spec)
   readr::stop_for_problems(val)
 
@@ -110,7 +112,7 @@ read_art_number <- function(file) {
     val$calendar_quarter <- NA_character_
 
   if("year" %in% names(val)) {
-    
+
     if(any(!is.na(val$calendar_quarter) &
            val$year != as.integer(substr(val$calendar_quarter, 3, 6))))
       stop("Inconsistent year and calendar_quarter found in ART dataset.")
@@ -137,7 +139,7 @@ read_anc_testing <- function(file) {
 
   required_cols <- c("area_id", "age_group", "year", "anc_clients",
                      "anc_known_pos", "anc_already_art", "anc_tested", "anc_tested_pos")
-  
+
   col_spec <- readr::cols_only(
                        area_id = readr::col_character(),
                        age_group = readr::col_character(),
@@ -148,7 +150,7 @@ read_anc_testing <- function(file) {
                        anc_tested = readr::col_double(),
                        anc_tested_pos = readr::col_double()
                      )
-  
+
   val <- readr_read_csv(file, col_types = col_spec)
   readr::stop_for_problems(val)
   stopifnot(na.omit(val$year) %% 1 == 0)
@@ -160,7 +162,7 @@ read_anc_testing <- function(file) {
   if(length(missing_cols))
     stop(paste0("Required columns not found: ", paste(missing_cols, collapse = ", ")))
 
-  
+
   ## !! TODO: add validation asserts -- probably pull in hintr validation_asserts.R
 
   val
@@ -188,14 +190,14 @@ read_area_merged <- function(file) {
 
 
 #' Read CSV with missing columns
-#' 
+#'
 #' This executes readr::read_csv with suppressing the warning for col_types that are
 #' explicitly specified but not found.
-#' 
+#'
 #' @param ... arguments to `readr::read_csv`.
 #' @return return from `readr::read_csv`.
-#' 
-#' @keywords internal 
+#'
+#' @keywords internal
 read_csv_partial_cols <- function(...){
   suppress_one_warning(readr_read_csv(...), "The following named parsers don't match the column names")
 }

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -148,5 +148,6 @@
     "INDICATOR_LABEL_AWARE_PLHIV_PROP": "Proportion of PLHIV aware of HIV positive status",
     "INDICATOR_LABEL_UNAWARE_PLHIV_NUM": "Number PLHIV unaware of HIV positive status",
     "OPTIONS_ADVANCED_OUTPUT_AWARE_LABEL": "Output 'awareness of HIV status' indicators",
-    "OPTIONS_ADVANCED_OUTPUT_AWARE_HELP": "Calculating awareness of HIV status indicators requires .shiny90 files to be included in each PJNZ. If .shiny90 files are not available, select 'No' to proceed with model fitting."
+    "OPTIONS_ADVANCED_OUTPUT_AWARE_HELP": "Calculating awareness of HIV status indicators requires .shiny90 files to be included in each PJNZ. If .shiny90 files are not available, select 'No' to proceed with model fitting.",
+    "POPULATION_REQUIRED_COLUMNS_MISSING": "Required columns not found: {{cols}}"
 }

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -105,7 +105,6 @@
     "INDICATOR_LABEL_ANC_ART_COVERAGE": "ART coverage among ANC attendees prior to first ANC",
     "OPTIONS_ART_TIME_VARYING_ART_ATTEND_LABEL": "Time-varying neighbouring district ART attendance",
     "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Allow the odds for seeking treatment in neighbouring district to change over time.",
-    "PROGRESS_VALIDATE_OPTIONS": "Validating inputs and options",
     "PROGRESS_PREPARE_INPUTS": "Preparing input data",
     "PROGRESS_FIT_MODEL": "Fitting the model",
     "PROGRESS_UNCERTAINTY": "Generating uncertainty ranges",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -105,7 +105,6 @@
     "INDICATOR_LABEL_ANC_ART_COVERAGE": "Couverture ART antérieure dans les cliniques prénatales",
     "OPTIONS_ART_TIME_VARYING_ART_ATTEND_LABEL": "Assiduité du ART des districts  voisinant variable avec le temps",
     "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Permettre la probabilité de demander un traitement dans des districts voisinant à changer avec le temps",
-    "PROGRESS_VALIDATE_OPTIONS": "Validation des entrées et des options",
     "PROGRESS_PREPARE_INPUTS": "Préparation des données d'entrée",
     "PROGRESS_FIT_MODEL": "Ajustement du modèle",
     "PROGRESS_UNCERTAINTY": "Génération de fourchettes d'incertitude",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -148,5 +148,6 @@
     "INDICATOR_LABEL_AWARE_PLHIV_PROP": "Proportion de PVVIH conscients de leur statut VIH positif",
     "INDICATOR_LABEL_UNAWARE_PLHIV_NUM": "Nombre de PVVIH non informés de leur statut VIH positif",
     "OPTIONS_ADVANCED_OUTPUT_AWARE_LABEL": "Indicateurs de sortie 'sensibilisation à la séropositivité'",
-    "OPTIONS_ADVANCED_OUTPUT_AWARE_HELP": "Le calcul de la connaissance des indicateurs de statut VIH nécessite l'inclusion de fichiers .shiny90 dans chaque PJNZ. Si les fichiers .shiny90 ne sont pas disponibles, sélectionnez «Non» pour procéder à l'ajustement du modèle."
+    "OPTIONS_ADVANCED_OUTPUT_AWARE_HELP": "Le calcul de la connaissance des indicateurs de statut VIH nécessite l'inclusion de fichiers .shiny90 dans chaque PJNZ. Si les fichiers .shiny90 ne sont pas disponibles, sélectionnez «Non» pour procéder à l'ajustement du modèle.",
+    "POPULATION_REQUIRED_COLUMNS_MISSING": "Colonnes obligatoires introuvables: {{cols}}"
 }

--- a/man/anc_testing_prev_mf.Rd
+++ b/man/anc_testing_prev_mf.Rd
@@ -3,12 +3,15 @@
 \name{anc_testing_prev_mf}
 \alias{anc_testing_prev_mf}
 \alias{anc_testing_artcov_mf}
+\alias{anc_testing_clients_mf}
 \alias{artnum_mf}
 \title{Prepare Model Frames for Programme Datasets}
 \usage{
 anc_testing_prev_mf(year, anc_testing, naomi_mf)
 
 anc_testing_artcov_mf(year, anc_testing, naomi_mf)
+
+anc_testing_clients_mf(year, anc_testing, naomi_mf, num_months)
 
 artnum_mf(calendar_quarter, art_number, naomi_mf)
 }

--- a/man/hintr_run_model.Rd
+++ b/man/hintr_run_model.Rd
@@ -11,7 +11,8 @@ hintr_run_model(
   spectrum_path = tempfile(fileext = ".zip"),
   coarse_output_path = tempfile(fileext = ".zip"),
   summary_report_path = tempfile(fileext = ".html"),
-  calibration_path = tempfile(fileext = ".rds")
+  calibration_path = tempfile(fileext = ".rds"),
+  validate = TRUE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ hintr_run_model(
 \item{summary_report_path}{Path to store summary report at.}
 
 \item{calibration_path}{Path to store data required for calibrating model.}
+
+\item{validate}{If FALSE validation of inputs & data will be skipped.}
 }
 \value{
 Paths to 4 output files.

--- a/man/mwi_anc_testing.Rd
+++ b/man/mwi_anc_testing.Rd
@@ -29,7 +29,7 @@ TODO: Link to mwi_areas dataset
 \item{\code{anc_tested_pos}}{Number of ANC clients testing HIV postive.}
 }
 
-An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 510 rows and 7 columns.
+An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) with 510 rows and 8 columns.
 }
 \source{
 Department of HIV & AIDS, Minitry of Health, Malawi.

--- a/man/select_naomi_data.Rd
+++ b/man/select_naomi_data.Rd
@@ -16,14 +16,21 @@ select_naomi_data(
   artnum_calendar_quarter_t1 = naomi_mf$calendar_quarter1,
   artnum_calendar_quarter_t2 = naomi_mf$calendar_quarter2,
  
+    anc_clients_year_t2 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter2)),
+  anc_clients_year_t2_num_months = 12,
+ 
     anc_prev_year_t1 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter1)),
  
     anc_prev_year_t2 = year_labels(calendar_quarter_to_quarter_id(naomi_mf$calendar_quarter2)),
   anc_artcov_year_t1 = anc_prev_year_t1,
   anc_artcov_year_t2 = anc_prev_year_t2,
+  use_kish_prev = TRUE,
   deff_prev = 1,
+  use_kish_artcov = TRUE,
   deff_artcov = 1,
+  use_kish_recent = TRUE,
   deff_recent = 1,
+  use_kish_vls = TRUE,
   deff_vls = 1
 )
 }
@@ -48,6 +55,8 @@ select_naomi_data(
 
 \item{artnum_calendar_quarter_t2}{Calendar quarter for second time point for number on ART.}
 
+\item{anc_clients_year_t2}{Calendar year (possibly multiple) for number of ANC clients at year 2.}
+
 \item{anc_prev_year_t1}{Calendar year (possibly multiple) for first time point for ANC prevalence.}
 
 \item{anc_prev_year_t2}{Calendar year (possibly multiple) for second time point for ANC prevalence.}
@@ -63,6 +72,8 @@ select_naomi_data(
 \item{deff_recent}{Approximate design effect for survey proportion recently infected.}
 
 \item{deff_vls}{Approximate design effect for survey viral load suppression.}
+
+\item{anc_clients_year_t2_num_monhts}{Number of months of reporting reflected in the year(s) recorded in \code{anc_clients_year_t2}.}
 }
 \description{
 Select data for model fitting

--- a/man/survey_mf.Rd
+++ b/man/survey_mf.Rd
@@ -9,6 +9,7 @@ survey_mf(
   indicator,
   survey_hiv_indicators,
   naomi_mf,
+  use_kish = TRUE,
   deff = 1,
   min_age = 0,
   max_age = 80
@@ -22,6 +23,8 @@ survey_mf(
 \item{survey_hiv_indicators}{Survey HIV indicators}
 
 \item{naomi_mf}{Naomi model frame}
+
+\item{use_kish}{Logical whether to use Kish effective sample size}
 
 \item{deff}{Assumed design effect for scaling effective sample size}
 

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -219,22 +219,21 @@ test_that("progress messages are printed", {
   })
   ## If using mock fit here there will only be 6, if using real
   ## fit_tmb there will be many more
-  expect_true(length(model_run$progress) >= 6)
+  expect_true(length(model_run$progress) >= 5)
   first_message <- model_run$progress[[1]]
-  expect_equal(first_message[[1]]$name, "Validating inputs and options")
-  expect_equal(first_message[[2]]$name, "Preparing input data")
-  expect_equal(first_message[[3]]$name, "Fitting the model")
-  expect_equal(first_message[[4]]$name, "Generating uncertainty ranges")
-  expect_equal(first_message[[5]]$name, "Preparing outputs")
+  expect_equal(first_message[[1]]$name, "Preparing input data")
+  expect_equal(first_message[[2]]$name, "Fitting the model")
+  expect_equal(first_message[[3]]$name, "Generating uncertainty ranges")
+  expect_equal(first_message[[4]]$name, "Preparing outputs")
   ## 5 different states
-  expect_equal(length(first_message), 5)
+  expect_equal(length(first_message), 4)
   expect_true(first_message[[1]]$started)
   expect_false(first_message[[1]]$complete)
   expect_false(first_message[[2]]$started)
   expect_false(first_message[[2]]$complete)
 
   second_message <- model_run$progress[[2]]
-  expect_equal(length(second_message), 5)
+  expect_equal(length(second_message), 4)
   expect_true(second_message[[1]]$started)
   expect_true(second_message[[1]]$complete)
   expect_true(second_message[[2]]$started)
@@ -610,3 +609,27 @@ test_that("progress can report on model fit", {
                "Itération 4 - 1h 5m 8s écoulées")
   expect_null(messages5$progress[[1]]$fit_model$helpText)
 })
+
+test_that("hintr_run_model can skip validation", {
+  options <- a_hintr_options
+  options$area_scope <- "MWI"
+  options$area_level <- 0
+
+  mock_validate_model_options <- mockery::mock(TRUE)
+
+  with_mock("naomi:::validate_model_options" = mock_validate_model_options, {
+    ## Don't really care about result here, just using some test that will
+    ## complete relatively quickly so we can test model validation is skipped
+    expect_error(hintr_run_model(format_data_input(a_hintr_data), options,
+                                 validate = FALSE))
+  })
+  mockery::expect_called(mock_validate_model_options, 0)
+
+  with_mock("naomi:::validate_model_options" = mock_validate_model_options, {
+    ## Don't really care about result here, just using some test that will
+    ## complete relatively quickly so we can test model validation is skipped
+    expect_error(hintr_run_model(format_data_input(a_hintr_data), options))
+  })
+  mockery::expect_called(mock_validate_model_options, 1)
+})
+

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -225,7 +225,7 @@ test_that("progress messages are printed", {
   expect_equal(first_message[[2]]$name, "Fitting the model")
   expect_equal(first_message[[3]]$name, "Generating uncertainty ranges")
   expect_equal(first_message[[4]]$name, "Preparing outputs")
-  ## 5 different states
+  ## 4 different states
   expect_equal(length(first_message), 4)
   expect_true(first_message[[1]]$started)
   expect_false(first_message[[1]]$complete)


### PR DESCRIPTION
This addresses #175 

I think useful to make this option as still instances (mostly when running programmatically i.e. when generating test data) when I want to be told about validation errors