### PR TITLE
fix new infections output scaling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.1.9
+Version: 2.1.10
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.1.10
+
+* Fix new infections scaling. In plotting outputs number of new infections were being inadvertently scaled x100 (reported by Lesotho estimates team).
+
 # naomi 2.1.9
 
 * Increase eppasm dependency to 0.5.9.

--- a/inst/metadata/metadata.csv
+++ b/inst/metadata/metadata.csv
@@ -13,7 +13,7 @@ output,choropleth,art_current,mean,lower,upper,indicator,art_current,t_(ART_NUMB
 output,choropleth,population,mean,lower,upper,indicator,population,t_(POPULATION),1,1000,0
 output,choropleth,plhiv,mean,lower,upper,indicator,plhiv,t_(PLHIV),1,100,0
 output,choropleth,incidence,mean,lower,upper,indicator,incidence,t_(INCIDENCE),1000,,0
-output,choropleth,infections,mean,lower,upper,indicator,infections,t_(NEW_INFECTIONS),100,100,0
+output,choropleth,infections,mean,lower,upper,indicator,infections,t_(NEW_INFECTIONS),1,100,0
 output,choropleth,aware_plhiv_prop,mean,lower,upper,indicator,aware_plhiv_prop,t_(AWARE_PLHIV_PROP),1,,0.0%
 output,choropleth,unaware_plhiv_num,mean,lower,upper,indicator,unaware_plhiv_num,t_(UNAWARE_PLHIV_NUM),1,10,0
 output,choropleth,untreated_plhiv_num,mean,lower,upper,indicator,untreated_plhiv_num,t_(UNTREATED_PLHIV_NUM),1,10,0
@@ -33,7 +33,7 @@ output,barchart,art_current,mean,lower,upper,indicator,art_current,t_(ART_NUMBER
 output,barchart,population,mean,lower,upper,indicator,population,t_(POPULATION),1,1000,0
 output,barchart,plhiv,mean,lower,upper,indicator,plhiv,t_(PLHIV),1,100,0
 output,barchart,incidence,mean,lower,upper,indicator,incidence,t_(INCIDENCE),1000,,0
-output,barchart,infections,mean,lower,upper,indicator,infections,t_(NEW_INFECTIONS),100,100,0
+output,barchart,infections,mean,lower,upper,indicator,infections,t_(NEW_INFECTIONS),1,100,0
 output,barchart,aware_plhiv_prop,mean,lower,upper,indicator,aware_plhiv_prop,t_(AWARE_PLHIV_PROP),1,,0.0%
 output,barchart,unaware_plhiv_num,mean,lower,upper,indicator,unaware_plhiv_num,t_(UNAWARE_PLHIV_NUM),1,10,0
 output,barchart,untreated_plhiv_num,mean,lower,upper,indicator,untreated_plhiv_num,t_(UNTREATED_PLHIV_NUM),1,10,0	


### PR DESCRIPTION
This fixes issue of new infections inadvertently being scaled x100 in the output visualisations. 

Reported by Athena Pantazis on behalf of Lesotho estimates team.
