### PR TITLE
depend first90 v1.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.1.11
+Version: 2.1.12
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",
@@ -24,7 +24,7 @@ Imports:
     data.tree,
     dplyr,
     eppasm (>= 0.5.9),
-    first90,
+    first90 (>= 1.4.2),
     forcats,
     fs,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naomi 2.1.12
+
+* Update dependency first90 v1.4.2 which ensures backwards compatibility for 
+  previous .shiny90 files.
+  
+
 # naomi 2.1.11
 
 * Catch error if output package construction returns NA error when calculating 


### PR DESCRIPTION
This bumps version dependency on first90 v1.4.2, which enables backwards compatibility for shiny90 files from 2019, 2020 or 2021.

I believe that the sequence needed is:

* Merge https://github.com/mrc-ide/first90release/pull/22
* Rebuild naomi.docker
* Run tests on this branch and ensure this fixes the failing test on master