### PR TITLE
Remove downstream hintr build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.1.13
+Version: 2.1.15
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.1.15
+Version: 2.1.13
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -2,21 +2,6 @@ steps:
   - label: ":whale: Build"
     command: docker/build
 
-  # The next step triggers a build on the hintr:
-  # https://buildkite.com/docs/pipelines/trigger-step
-  #
-  # This triggers on every hint build so that we can check that the
-  # changes work with hintr, and pass the naomi sha through an
-  # environment variable.  The build is against hintr master
-  - trigger: "hintr"
-    label: ":rocket: hintr (from naomi) :docker:"
-    async: true
-    build:
-      # branch: master # TODO <- set this one back once hintr merged
-      branch: master
-      env:
-        NAOMI_SHA: "${BUILDKITE_COMMIT}"
-
   - wait
 
   - label: ":hammer: Test"


### PR DESCRIPTION
This will now be triggered by the PR created by vimc-robot. I am going to remove the bumped version no which I added here for testing and close the downstream PR but they should prove this is working.