### PR TITLE
Logistic calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.2.5
+Version: 2.3.0
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.3.0
+
+* Fix to model calibration for number aware of status to align with proportion aware 
+  of status and number unaware of status.
+  
 # naomi 2.2.5
 
 * Add BWA, HTI, and COD to PEPFAR Data Pack PSNU list

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
 # naomi 2.3.0
 
+* Implement 'logistic' scaling option for [`calibrate_outputs()`] such that estimates are
+  adjusted on logistic scale by fine district/sex/age group to ensure proportions do 
+  not go above 100%.
+  - Note: implementation does not yet handle uncertainty ranges. Those might still go above
+    100%.
 * Fix to model calibration for number aware of status to align with proportion aware 
   of status and number unaware of status.
-  
+
+
 # naomi 2.2.5
 
 * Add BWA, HTI, and COD to PEPFAR Data Pack PSNU list

--- a/R/model-options.R
+++ b/R/model-options.R
@@ -65,7 +65,9 @@ get_calibration_option_labels <- function(options) {
     age_coarse = "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_COARSE_LABEL)",
     sex_age_coarse = "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_COARSE_LABEL)",
     age_group = "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_GROUP_LABEL)",
-    sex_age_group = "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_GROUP_LABEL)"
+    sex_age_group = "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_GROUP_LABEL)",
+    logistic = "t_(OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL)",
+    proportional = "t_(OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL)"
   )
   calibration_option_map <- traduire::translator()$replace(
     calibration_option_map)

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1070,7 +1070,9 @@ calibrate_outputs <- function(output,
       dplyr::ungroup()
 
     if (naomi_mf$output_aware_plhiv) {
-      val_wide_adj <- dplyr::group_by_at(aware_aggr_var) %>%
+
+      val_wide_adj <- val_wide_adj %>%
+        dplyr::group_by_at(aware_aggr_var) %>%
         dplyr::mutate(
                  adjusted_unaware_plhiv_num =
                    calibrate_logistic_one(mean_unaware_plhiv_num,

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -994,7 +994,7 @@ calibrate_outputs <- function(output,
                   infections_spectrum, infections_raw, infections_calibration, infections_final)
 
 
-  ## Calculate calibrated PLHIV at finest stratification (mf_model)
+  ## Calculate calibrated values at finest stratification (mf_model)
 
   val <- val %>%
     dplyr::left_join(
@@ -1013,6 +1013,8 @@ calibrate_outputs <- function(output,
     dplyr::mutate(adjusted = mean * calibration)
 
 
+  ## Aggregate adjusted fine stratification values
+  
   .expand <- function(cq, ind) {
 
     byv <- c("area_id", "sex", "spectrum_region_code", "age_group")
@@ -1111,8 +1113,6 @@ calibrate_outputs <- function(output,
 
   if (naomi_mf$output_aware_plhiv) {
 
-    browser()
-    
     aware_calibration <- out %>%
       dplyr::filter(
                indicator %in% c("plhiv", "unaware_plhiv_num", "aware_plhiv_prop", "aware_plhiv_num")

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -115,7 +115,7 @@ extract_indicators <- function(naomi_fit, naomi_mf) {
                        "aware_plhiv_num_t3_out" = "aware_plhiv_num",
                        "unaware_plhiv_num_t3_out" = "unaware_plhiv_num")
   }
-  
+
   indicator_est_t1 <- Map(get_est, names(indicators_t1), indicators_t1, naomi_mf$calendar_quarter1)
   indicator_est_t2 <- Map(get_est, names(indicators_t2), indicators_t2, naomi_mf$calendar_quarter2)
   indicator_est_t3 <- Map(get_est, names(indicators_t3), indicators_t3, naomi_mf$calendar_quarter3)
@@ -143,7 +143,7 @@ extract_indicators <- function(naomi_fit, naomi_mf) {
                          "anc_tested_neg_t2_out" = "anc_tested_neg",
                          "anc_rho_t2_out" = "anc_prevalence",
                          "anc_alpha_t2_out" = "anc_art_coverage")
-  
+
   indicators_anc_t3 <- c("anc_clients_t3_out" = "anc_clients",
                          "anc_plhiv_t3_out" = "anc_plhiv",
                          "anc_already_art_t3_out" = "anc_already_art",
@@ -154,7 +154,7 @@ extract_indicators <- function(naomi_fit, naomi_mf) {
                          "anc_rho_t3_out" = "anc_prevalence",
                          "anc_alpha_t3_out" = "anc_art_coverage")
 
-  
+
   indicator_anc_est_t1 <- Map(get_est, names(indicators_anc_t1), indicators_anc_t1,
                               naomi_mf$calendar_quarter1, list(naomi_mf$mf_anc_out))
   indicator_anc_est_t2 <- Map(get_est, names(indicators_anc_t2), indicators_anc_t2,
@@ -763,10 +763,10 @@ generate_output_summary_report <- function(report_path,
     fs::file_copy(list.files(system_file("report"), full.names = TRUE), ".")
 
     rmarkdown::render("summary_report.Rmd", params = list(
-      output_zip = output_zip_path),
-      output_file = report_filename,
-      quiet = quiet
-    )
+                                              output_zip = output_zip_path),
+                      output_file = report_filename,
+                      quiet = quiet
+                      )
 
     fs::file_copy(report_filename, report_path_dir, overwrite = TRUE)
   })
@@ -859,10 +859,12 @@ calibrate_outputs <- function(output,
                               spectrum_aware_calibration_level,
                               spectrum_aware_calibration_strat,
                               spectrum_infections_calibration_level,
-                              spectrum_infections_calibration_strat) {
+                              spectrum_infections_calibration_strat,
+                              calibrate_method = "logistic") {
 
   stopifnot(inherits(output, "naomi_output"))
   stopifnot(inherits(naomi_mf, "naomi_mf"))
+  stopifnot(calibrate_method %in% c("logistic", "proportional"))
 
   group_vars <- c("spectrum_region_code", "calendar_quarter", "sex", "age_group")
 
@@ -883,14 +885,13 @@ calibrate_outputs <- function(output,
   ## Add ID columns to merge to spectrum_calibration data frame.
   val <- indicators %>%
     dplyr::filter(indicator %in%
-                  c("plhiv", "art_current_residents", "aware_plhiv_num", "unaware_plhiv_num", "infections")) %>%
+                  c("population", "plhiv", "art_current_residents", "aware_plhiv_num", "unaware_plhiv_num", "infections")) %>%
     dplyr::inner_join(mf, by = c("area_id", "sex", "age_group")) %>%
     dplyr::select(area_id, indicator, tidyselect::all_of(group_vars), mean)
 
   val_aggr <- val %>%
     dplyr::group_by_at(c("indicator", group_vars)) %>%
-    dplyr::summarise(est_raw = sum(mean)) %>%
-    dplyr::ungroup()
+    dplyr::summarise(est_raw = sum(mean), .groups = "drop")
 
   ## Table of target values from Spectrum
   spectrum_calibration <- naomi_mf$spectrum_calibration %>%
@@ -913,9 +914,13 @@ calibrate_outputs <- function(output,
            ) %>%
     tidyr::pivot_wider(names_from = indicator, values_from = est_raw)
 
+  if (is.null(val_aggr_wide[["unaware_raw"]])) {
+    val_aggr_wide[["unaware_raw"]] <- NA_real_
+  }
+
   spectrum_calibration <- spectrum_calibration %>%
     dplyr::left_join(val_aggr_wide, by = group_vars)
-  
+
 
   ## Calculate calibration ratios for PLHIV, ART number, and new infections
 
@@ -948,7 +953,7 @@ calibrate_outputs <- function(output,
   }
 
   aware_aggr_var <- get_spectrum_aggr_var(spectrum_aware_calibration_level,
-                                           spectrum_aware_calibration_strat)
+                                          spectrum_aware_calibration_strat)
 
   if(length(aware_aggr_var) > 0L) {
 
@@ -975,7 +980,7 @@ calibrate_outputs <- function(output,
   } else {
     spectrum_calibration$infections_calibration <- 1.0
   }
-  
+
   spectrum_calibration <- spectrum_calibration %>%
     dplyr::mutate(plhiv_final = plhiv_raw * plhiv_calibration,
                   art_current_final = art_current_raw * art_current_calibration,
@@ -983,7 +988,7 @@ calibrate_outputs <- function(output,
 
   ## Will be NA if output_aware_plhiv = FALSE
   spectrum_calibration$unaware_final <- spectrum_calibration$unaware_raw * spectrum_calibration$unaware_calibration
-    
+
 
   spectrum_calibration <- spectrum_calibration %>%
     dplyr::select(spectrum_region_code, sex, age_group, calendar_quarter,
@@ -996,7 +1001,7 @@ calibrate_outputs <- function(output,
 
   ## Calculate calibrated values at finest stratification (mf_model)
 
-  val <- val %>%
+  val_adj <- val %>%
     dplyr::left_join(
              spectrum_calibration %>%
              dplyr::select(
@@ -1012,13 +1017,89 @@ calibrate_outputs <- function(output,
            ) %>%
     dplyr::mutate(adjusted = mean * calibration)
 
+  ## Logistic scaling adjustment
+  if (calibrate_method == "logistic") {
+    val_wide <- val_adj %>%
+      tidyr::pivot_wider(c(area_id, group_vars), names_from = indicator, values_from = c(mean, adjusted))
+
+    val_wide <- val_wide %>%
+      dplyr::mutate(age_coarse = dplyr::if_else(
+                                          age_group %in% c("Y000_004", "Y005_009", "Y010_014"),
+                                          "Y000_014", "Y015_999"))
+
+
+    calibrate_logistic_one <- function(numerator_vector,
+                                       denominator_vector,
+                                       denominator_new,
+                                       target_vector) {
+
+      target_val <- sum(target_vector)
+      logit_p_fine <- qlogis(numerator_vector / denominator_vector)
+      adjust_numerator <- function(theta, l, d) plogis(l + theta) * d
+      optfn <- function(theta) (sum(adjust_numerator(theta, logit_p_fine, denominator_new)) - target_val)^2
+      opt <- optimise(optfn, c(-10, 10), tol = .Machine$double.eps^0.5)
+
+      adjust_numerator(opt$minimum, logit_p_fine, denominator_new)
+    }
+
+
+
+    val_wide_adj <- val_wide %>%
+      dplyr::group_by_at(plhiv_aggr_var) %>%
+      dplyr::mutate(
+               adjusted_plhiv = calibrate_logistic_one(mean_plhiv,
+                                                       mean_population,
+                                                       mean_population,
+                                                       adjusted_plhiv)
+             ) %>%
+      dplyr::group_by_at(artnum_aggr_var) %>%
+      dplyr::mutate(
+               adjusted_art_current_residents =
+                 calibrate_logistic_one(mean_art_current_residents,
+                                        mean_plhiv,
+                                        adjusted_plhiv,
+                                        adjusted_art_current_residents)) %>%
+      dplyr::group_by_at(infections_aggr_var) %>%
+      dplyr::mutate(
+               adjusted_infections =
+                 calibrate_logistic_one(mean_infections,
+                                        mean_population - mean_plhiv,
+                                        mean_population - adjusted_plhiv,
+                                        adjusted_infections)
+             ) %>%
+      dplyr::ungroup()
+
+    if (naomi_mf$output_aware_plhiv) {
+      val_wide_adj <- dplyr::group_by_at(aware_aggr_var) %>%
+        dplyr::mutate(
+                 adjusted_unaware_plhiv_num =
+                   calibrate_logistic_one(mean_unaware_plhiv_num,
+                                          mean_plhiv - mean_art_current_residents,
+                                          adjusted_plhiv - adjusted_art_current_residents,
+                                          adjusted_unaware_plhiv_num)
+               ) %>%
+        dplyr::ungroup()
+      
+    } else {
+      val_wide_adj$adjusted_unaware_plhiv_num <- NA_real_
+    }
+    
+    val_adj <- val_wide_adj %>%
+      dplyr::rename(plhiv = adjusted_plhiv,
+                    art_current_residents = adjusted_art_current_residents,
+                    unaware_plhiv_num = adjusted_unaware_plhiv_num,
+                    infections = adjusted_infections) %>%
+      tidyr::pivot_longer(c(plhiv, art_current_residents, unaware_plhiv_num, infections),
+                          names_to = "indicator", values_to = "adjusted") %>%
+      dplyr::select("area_id", tidyselect::all_of(group_vars), indicator, adjusted)
+  }
 
   ## Aggregate adjusted fine stratification values
-  
+
   .expand <- function(cq, ind) {
 
     byv <- c("area_id", "sex", "spectrum_region_code", "age_group")
-    m <- dplyr::filter(val, calendar_quarter == cq, indicator == ind)
+    m <- dplyr::filter(val_adj, calendar_quarter == cq, indicator == ind)
     m <- dplyr::left_join(mf, m, by = byv)
 
     val <- mfout
@@ -1038,7 +1119,7 @@ calibrate_outputs <- function(output,
                   .expand(naomi_mf$calendar_quarter3, "art_current_residents"),
                   .expand(naomi_mf$calendar_quarter1, "unaware_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter2, "unaware_plhiv_num"),
-                  .expand(naomi_mf$calendar_quarter3, "unaware_plhiv_num"),                  
+                  .expand(naomi_mf$calendar_quarter3, "unaware_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter1, "infections"),
                   .expand(naomi_mf$calendar_quarter2, "infections"),
                   .expand(naomi_mf$calendar_quarter3, "infections")
@@ -1080,9 +1161,9 @@ calibrate_outputs <- function(output,
              lower = lower * calibration,
              upper = upper * calibration
            )
-  
+
   out <- dplyr::select(out, names(output$indicators))
-  
+
   incidence_calibration <- out %>%
     dplyr::filter(indicator %in% c("population", "plhiv", "infections", "incidence")) %>%
     tidyr::pivot_wider(
@@ -1130,7 +1211,7 @@ calibrate_outputs <- function(output,
              ) %>%
       dplyr::select(area_id, sex, age_group, calendar_quarter,
                     aware_num_calibration, aware_prop_calibration)
-    
+
     out <- out %>%
       dplyr::left_join(aware_calibration,
                        by = c("area_id", "sex", "age_group", "calendar_quarter")) %>%
@@ -1146,7 +1227,7 @@ calibrate_outputs <- function(output,
                upper = upper * calibration
              ) %>%
       dplyr::select(names(output$indicators))
-  } 
+  }
 
   ## Save calibration options
 
@@ -1298,4 +1379,3 @@ disaggregate_0to4_outputs <- function(output, naomi_mf) {
 
   output
 }
-

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -119,7 +119,8 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
                                options$spectrum_aware_calibration_level,
                                options$spectrum_aware_calibration_strat,
                                options$spectrum_infections_calibration_level,
-                               options$spectrum_infections_calibration_strat)
+                               options$spectrum_infections_calibration_strat,
+                               options$calibrate_method)
 
   outputs <- disaggregate_0to4_outputs(outputs, naomi_data)
 
@@ -206,7 +207,8 @@ hintr_calibrate <- function(output, calibration_options,
     spectrum_aware_calibration_level = calibration_options$spectrum_aware_calibration_level,
     spectrum_aware_calibration_strat = calibration_options$spectrum_aware_calibration_strat,
     spectrum_infections_calibration_level = calibration_options$spectrum_infections_calibration_level,
-    spectrum_infections_calibration_strat = calibration_options$spectrum_infections_calibration_strat
+    spectrum_infections_calibration_strat = calibration_options$spectrum_infections_calibration_strat,
+    calibrate_method = calibration_options$calibrate_method
   )
 
   calibrated_output <- disaggregate_0to4_outputs(output = calibrated_output,
@@ -234,6 +236,7 @@ hintr_calibrate <- function(output, calibration_options,
 }
 
 validate_calibrate_options <- function(calibration_options) {
+  
   expected_options <- c("spectrum_plhiv_calibration_level",
                         "spectrum_plhiv_calibration_strat",
                         "spectrum_artnum_calibration_level",
@@ -241,13 +244,19 @@ validate_calibrate_options <- function(calibration_options) {
                         "spectrum_aware_calibration_level",
                         "spectrum_aware_calibration_strat",
                         "spectrum_infections_calibration_level",
-                        "spectrum_infections_calibration_strat")
+                        "spectrum_infections_calibration_strat",
+                        "calibrate_method")
   missing_options <- expected_options[
     !(expected_options %in% names(calibration_options))]
   if (length(missing_options) > 0) {
     stop(t_("Calibration cannot be run, missing options for {{missing}}.",
                  list(missing = paste(missing_options, collapse = ", "))))
   }
+
+  if (!all(calibration_options[["calibrate_method"]] %in% c("logistic", "proportional"))) {
+    stop(t_("calibrate_method must be either \"logistic\" or \"proportional\""))
+  }
+    
   invisible(TRUE)
 }
 
@@ -572,6 +581,9 @@ format_options <- function(options) {
   }
   if (is.null(options$spectrum_infections_strat)) {
     options$spectrum_infections_calibration_strat <- "sex_age_coarse"
+  }
+  if (is.null(options$calibrate_method)) {
+    options$calibrate_method <- "logistic"
   }
 
 

--- a/inst/metadata/calibration_run_options.json
+++ b/inst/metadata/calibration_run_options.json
@@ -214,5 +214,25 @@
         }
       ]
     }
+    {
+      "label": "t_(OPTIONS_CALIBRATE_METHOD_LABEL)",
+      "controls": [
+        {
+          "name": "calibrate_method",
+          "type": "select",
+          "required": true,
+          "options": [
+            {
+              "id": "logistic",
+              "label": "t_(OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL)"
+            },
+            {
+              "id": "proportional",
+              "label": "t_(OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL)"
+            }
+	  ]
+        }
+      ]
+    }      
   ]
 }

--- a/inst/metadata/calibration_run_options.json
+++ b/inst/metadata/calibration_run_options.json
@@ -213,7 +213,7 @@
           "helpText": "t_(OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_INFECTIONS_HELP)"
         }
       ]
-    }
+    },
     {
       "label": "t_(OPTIONS_CALIBRATE_METHOD_LABEL)",
       "controls": [

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -174,5 +174,8 @@
     "OPTIONS_11_MONTHS": "11 months",
     "OPTIONS_12_MONTHS": "12 months",
     "OPTIONS_USE_SURVEY_AGGREGATE_LABEL": "Use aggregate survey dataset",
-    "OPTIONS_USE_SURVEY_AGGREGATE_HELP": "The uploaded survey dataset must be subsetted to exactly the data to be used in model calibration."
+    "OPTIONS_USE_SURVEY_AGGREGATE_HELP": "The uploaded survey dataset must be subsetted to exactly the data to be used in model calibration.",
+    "OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL": "Logistic",
+    "OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL": "Proportional",
+    "OPTIONS_CALIBRATE_METHOD_LABEL": "Calibration method"
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -174,5 +174,8 @@
     "OPTIONS_11_MONTHS": "11 mois",
     "OPTIONS_12_MONTHS": "12 mois",
     "OPTIONS_USE_SURVEY_AGGREGATE_LABEL": "Utiliser un ensemble de données d'enquête agrégées",
-    "OPTIONS_USE_SURVEY_AGGREGATE_HELP": "L'ensemble de données d'enquête téléchargé doit être sous-défini exactement aux données à utiliser dans le calibrage du modèle."
+    "OPTIONS_USE_SURVEY_AGGREGATE_HELP": "L'ensemble de données d'enquête téléchargé doit être sous-défini exactement aux données à utiliser dans le calibrage du modèle.",
+    "OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL": "Logistique",
+    "OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL": "Proportionnelle",
+    "OPTIONS_CALIBRATE_METHOD_LABEL": "Méthode d'étalonnage"
 }

--- a/tests/testthat/setup-model-frame.R
+++ b/tests/testthat/setup-model-frame.R
@@ -27,9 +27,12 @@ a_tmb_inputs <- prepare_tmb_inputs(a_naomi_data)
 a_fit <- fit_tmb(a_tmb_inputs, outer_verbose = FALSE)
 a_fit_sample <- sample_tmb(a_fit, nsample = 30, rng_seed = 28)
 a_output <- output_package(a_fit_sample, a_naomi_mf)
+
 a_output_calib <- calibrate_outputs(a_output, a_naomi_data,
                                     "none", "sex_age_coarse",
                                     "none", "sex_age_coarse",
                                     "none", "sex_age_coarse",
-                                    "none", "sex_age_coarse")
+                                    "none", "sex_age_coarse",
+                                    calibrate_method = "logistic")
+
 a_output_full  <- disaggregate_0to4_outputs(a_output_calib, a_naomi_data)

--- a/tests/testthat/setup-run-model.R
+++ b/tests/testthat/setup-run-model.R
@@ -59,7 +59,8 @@ a_hintr_calibration_options <- list(
   spectrum_aware_calibration_level = "national",
   spectrum_aware_calibration_strat = "age_coarse",
   spectrum_infections_calibration_level = "none",
-  spectrum_infections_calibration_strat = "age_coarse"
+  spectrum_infections_calibration_strat = "age_coarse",
+  calibrate_method = "logistic"
 )
 
 ## Use fit.RDS if it exists locally, otherwise just use the actual functions

--- a/tests/testthat/test-model-options.R
+++ b/tests/testthat/test-model-options.R
@@ -215,8 +215,11 @@ test_that("can get model calibration options label from ID", {
                   spectrum_plhiv_calibration_strat = "sex_age_group" ,
                   spectrum_artnum_calibration_level = "none",
                   spectrum_artnum_calibration_strat = "age_coarse",
+                  spectrum_aware_calibration_level = "none",
+                  spectrum_aware_calibration_strat = "age_coarse",
                   spectrum_infections_calibration_level = "none",
-                  spectrum_infections_calibration_strat ="age_coarse")
+                  spectrum_infections_calibration_strat ="age_coarse",
+                  calibrate_method = "logistic")
   options_map <- get_calibration_option_labels(options)
 
   expect_length(options_map, length(options))
@@ -225,8 +228,11 @@ test_that("can get model calibration options label from ID", {
     spectrum_plhiv_calibration_strat = "Sex and 5-year age group",
     spectrum_artnum_calibration_level = "None",
     spectrum_artnum_calibration_strat = "Age <15 / 15+",
+    spectrum_aware_calibration_level = "None",
+    spectrum_aware_calibration_strat = "Age <15 / 15+",
     spectrum_infections_calibration_level = "None",
-    spectrum_infections_calibration_strat ="Age <15 / 15+"))
+    spectrum_infections_calibration_strat ="Age <15 / 15+",
+    calibrate_method = "Logistic"))
 })
 
 test_that("validate_model_options() returns error if missing .shiny90", {

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -289,6 +289,7 @@ test_that("setting rng_seed returns same output", {
   options$spectrum_artnum_calibration_level <- "none"
   options$spectrum_aware_calibration_level <- "none"
   options$spectrum_infections_calibration_level <- "none"
+  options$calibrate_method <- "logistic"
 
   output_path <- tempfile()
   output_spectrum <- tempfile(fileext = ".zip")
@@ -542,7 +543,8 @@ test_that("model run can be calibrated", {
     spectrum_aware_calibration_level = "subnational",
     spectrum_aware_calibration_strat = "age_coarse",
     spectrum_infections_calibration_level = "none",
-    spectrum_infections_calibration_strat = "age_coarse"
+    spectrum_infections_calibration_strat = "age_coarse",
+    calibrate_method = "logistic"
   )
   calibrated_output_2 <- hintr_calibrate(calibrated_output,
                                          calibration_options)
@@ -867,7 +869,8 @@ test_that("validate_calibrate_options errors if required options are missing", {
     "spectrum_artnum_calibration_level" = "none",
     "spectrum_artnum_calibration_strat" = "none",
     "spectrum_aware_calibration_level" = "none",
-    "spectrum_aware_calibration_strat" = "none")),
+    "spectrum_aware_calibration_strat" = "none",
+    "calibrate_method" = "logistic")),
     paste0("Calibration cannot be run, missing options for ",
            "spectrum_infections_calibration_level, ",
            "spectrum_infections_calibration_strat."))
@@ -881,7 +884,8 @@ test_that("validate_calibrate_options errors if required options are missing", {
     "spectrum_artnum_calibration_strat" = "none",
     "spectrum_aware_calibration_level" = "none",
     "spectrum_aware_calibration_strat" = "none",
-    "spectrum_infections_calibration_level" = "none")),
+    "spectrum_infections_calibration_level" = "none",
+    "calibrate_method" = "logistic")),
     paste0("Calibration cannot be run, missing options for ",
            "spectrum_infections_calibration_strat."))
 
@@ -894,5 +898,33 @@ test_that("validate_calibrate_options errors if required options are missing", {
     "spectrum_aware_calibration_level" = "none",
     "spectrum_aware_calibration_strat" = "none",
     "spectrum_infections_calibration_level" = "none",
-    "spectrum_infections_calibration_strat" = "none")))
+    "spectrum_infections_calibration_strat" = "none",
+    "calibrate_method" = "logistic")))
+
+  expect_error(validate_calibrate_options(list(
+    "spectrum_plhiv_calibration_level" = "none",
+    "spectrum_plhiv_calibration_level" = "none",
+    "spectrum_plhiv_calibration_strat" = "none",
+    "spectrum_artnum_calibration_level" = "none",
+    "spectrum_artnum_calibration_strat" = "none",
+    "spectrum_aware_calibration_level" = "none",
+    "spectrum_aware_calibration_strat" = "none",
+    "spectrum_infections_calibration_level" = "none",
+    "spectrum_infections_calibration_strat" = "none")),
+    paste0("Calibration cannot be run, missing options for ",
+           "calibrate_method."))
+
+  expect_error(validate_calibrate_options(list(
+    "spectrum_plhiv_calibration_level" = "none",
+    "spectrum_plhiv_calibration_level" = "none",
+    "spectrum_plhiv_calibration_strat" = "none",
+    "spectrum_artnum_calibration_level" = "none",
+    "spectrum_artnum_calibration_strat" = "none",
+    "spectrum_aware_calibration_level" = "none",
+    "spectrum_aware_calibration_strat" = "none",
+    "spectrum_infections_calibration_level" = "none",
+    "spectrum_infections_calibration_strat" = "none",
+    "calibrate_method" = "JIBBERISH")),
+    paste0("calibrate_method must be either \"logistic\" or \"proportional\""))
+
 })


### PR DESCRIPTION
This PR adds an option for 'logistic' calibration option which scales proportions on the logistic scale to ensure coverages don't go above 100%. This is set as the default calibration option.

Key changes:

* Additional argument to the function `calibrate_outputs()`.
* Additional select option on the Calibration Options page.

When/if this passes hintr tests, it would be helpful to see this on staging server to ensure the Calibration model option page updates are correct.