### PR TITLE
set default for calibrate_method in JSON schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.0
+Version: 2.3.1
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.3.1
+
+* Set default for `calibrate_method` model option in user interface via JSON metadata.
+* Fix swapped indicator_code and indicator_id for Data Pack metadata which were swapped.
+
 # naomi 2.3.0
 
 * Implement 'logistic' scaling option for [`calibrate_outputs()`] such that estimates are

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Set default for `calibrate_method` model option in user interface via JSON metadata.
 * Fix swapped indicator_code and indicator_id for Data Pack metadata which were swapped.
+* Refactor [`calibrate_outputs()`]; handle uncertainty ranges for proportion adjustments.
 
 # naomi 2.3.0
 

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -844,9 +844,70 @@ subset_output_package <- function(path, output_path, ...) {
 
 
 
-## !!! TODO: Documentation and tests
-
 #' Calibrate naomi model outputs
+#'
+#' @param output Naomi model output package produced by [`output_package()`].
+#' @param naomi_mf Naomi model frame, objective of class `naomi_mf`.
+#' @param spectrum_plhiv_calibration_level Level to calibrate PLHIV, see details.
+#' @param spectrum_plhiv_calibration_strat Age/sex stratification to calibrate PLHIV, see details.
+#' @param spectrum_artnum_calibration_level Level to calibrate number on ART, see details.
+#' @param spectrum_artnum_calibration_strat Age/sex stratification to calibrate number on ART, see details.
+#' @param spectrum_aware_calibration_level Level to calibrate number aware of HIV positive status, see details.
+#' @param spectrum_aware_calibration_strat Age/sex stratification to calibrate number aware of HIV positive status, see details.
+#' @param spectrum_infections_calibration_level Level to calibrate number infections of HIV positive status, see details.
+#' @param spectrum_infections_calibration_strat Age/sex stratification to calibrate number infections of HIV positive status, see details.
+#' @param calibrate_method Calibration method, either `"logistic"` (default) or `"proportional"`.
+#'
+#' @details
+#'
+#' The following indicators are calibrated:
+#'
+#' * `plhiv`
+#' * `art_current_residents`
+#' * `unaware_plhiv_num`
+#' * `infections`
+#' * `art_current` (attending)
+#' * `aware_plhiv_num`
+#' * `untreated_plhiv_num`
+#' * `prevalence`
+#' * `art_coverage`
+#' * `aware_plhiv_prop`
+#' * `incidence`
+#'
+#' Steps in the calibration:
+#'
+#' 1. Aggregate Spectrum totals to specified stratification by level/sex/age to
+#'    calculate the target totals within each stratification.
+#' 2. Adjust fine area/sex/age-group mean values to match targeted total using
+#'    either "logistic" or "proportional" scaling.
+#' 3. Aggregate revised mean count values to all stratifications of Naomi outputs.
+#' 4. Calculate calibrated mean for proportion indicators.
+#' 5. Adjust outputs for all statistics (mean, median, mode, se, range).
+#' 6. Aggregate totals spectrum_calibration table.
+#'
+#'
+#' The "logistic" scaling method converts fine counts to logit proportions, then
+#' uses numerical optimisation to solve the logit-scale adjustment to the fine
+#' district/sex/age proportions such that the adjusted proportions times the
+#' denominator sums to the target value.
+#'
+#' Calibration proceeds sequentially through the following indicators.
+#' * PLHIV
+#' * Number of residents on ART
+#' * Number unaware of HIV status
+#' * Number of new infections
+#' * Number of attending ANC by district
+#'
+#' Calibration of a previous indicator may affect the denominator for the next
+#' indicator. This does not affect the calculation for proportional scaling,
+#' but will affect logistic scaling. Inconsistent selections for calibration
+#' levels or stratifications could result in a denominator smaller than a target
+#' numerator for a particular value. This will throw an error for logistic
+#' scaling methods.
+#'
+#'
+#' The number of attending ARG clients is always calibrated proportionally by
+#' sex and five-year age group to the number or residents attending.
 #'
 #' @importMethodsFrom Matrix %*%
 #' @export
@@ -885,13 +946,10 @@ calibrate_outputs <- function(output,
   ## Add ID columns to merge to spectrum_calibration data frame.
   val <- indicators %>%
     dplyr::filter(indicator %in%
-                  c("population", "plhiv", "art_current_residents", "aware_plhiv_num", "unaware_plhiv_num", "infections")) %>%
+                  c("population", "plhiv", "art_current_residents", "art_current", "aware_plhiv_num", "unaware_plhiv_num", "infections")) %>%
     dplyr::inner_join(mf, by = c("area_id", "sex", "age_group")) %>%
     dplyr::select(area_id, indicator, tidyselect::all_of(group_vars), mean)
 
-  val_aggr <- val %>%
-    dplyr::group_by_at(c("indicator", group_vars)) %>%
-    dplyr::summarise(est_raw = sum(mean), .groups = "drop")
 
   ## Table of target values from Spectrum
   spectrum_calibration <- naomi_mf$spectrum_calibration %>%
@@ -899,7 +957,11 @@ calibrate_outputs <- function(output,
                                         age_group %in% c("Y000_004", "Y005_009", "Y010_014"),
                                         "Y000_014", "Y015_999"))
 
-  ## Table of raw mean estimates
+  ## Join aggregates of raw Naomi mean to archive
+  val_aggr <- val %>%
+    dplyr::group_by_at(c("indicator", group_vars)) %>%
+    dplyr::summarise(est_raw = sum(mean), .groups = "drop")
+
   val_aggr_wide <- val_aggr %>%
     dplyr::filter(
              indicator %in% c("plhiv", "art_current_residents",
@@ -922,183 +984,226 @@ calibrate_outputs <- function(output,
     dplyr::left_join(val_aggr_wide, by = group_vars)
 
 
-  ## Calculate calibration ratios for PLHIV, ART number, and new infections
+  ## Calculate calibration adjustments for means PLHIV, ART number, and new infections
 
+  valmean_wide <- val %>%
+    tidyr::pivot_wider(c(area_id, tidyselect::all_of(group_vars)),
+                       names_from = indicator, values_from = mean) %>%
+    dplyr::mutate(
+             age_coarse = dplyr::if_else(
+                                   age_group %in% c("Y000_004", "Y005_009", "Y010_014"),
+                                   "Y000_014", "Y015_999")
+           )
+
+  if (!naomi_mf$output_aware_plhiv) {
+    valmean_wide$unaware_plhiv_num <- NA_real_
+  }
+    
+  valmean_wide <- valmean_wide %>%
+    dplyr::mutate(
+             prevalence = plhiv / population,
+             art_coverage = art_current_residents / plhiv,
+             unaware_plhiv_prop = unaware_plhiv_num / (plhiv - art_current_residents),
+             incidence = infections / (population - plhiv)
+           )
+
+  calibrate_logistic_one <- function(proportion_raw,
+                                     denominator_new,
+                                     target_val) {
+
+    stopifnot(proportion_raw >= 0)
+    stopifnot(proportion_raw <= 1)
+    stopifnot(target_val == target_val[1])
+    target_val <- target_val[1]
+
+    if (sum(denominator_new) < target_val) {
+      stop("Error in logistic calibration: target numerator is larger than aggregated denominator.")
+    }
+
+    logit_p_fine <- qlogis(proportion_raw)
+    adjust_numerator <- function(theta, l, d) plogis(l + theta) * d
+    optfn <- function(theta) (sum(adjust_numerator(theta, logit_p_fine, denominator_new)) - target_val)^2
+    opt <- optimise(optfn, c(-10, 10), tol = .Machine$double.eps^0.5)
+
+    adjust_numerator(opt$minimum, logit_p_fine, denominator_new)
+  }
+
+  calibrate_proportional_one <- function(value_raw, target_val) {
+
+    stopifnot(target_val == target_val[1])
+    target_val <- target_val[1]
+
+    value_raw * target_val / sum(value_raw)
+  }
+
+  calibrate_one <- function(value_raw, proportion_raw, denominator_new,
+                            target_val, calibrate_method) {
+
+    if (calibrate_method == "logistic") {
+      val <- calibrate_logistic_one(proportion_raw, denominator_new, target_val)
+    } else if (calibrate_method == "proportional") {
+      val <- calibrate_proportional_one(value_raw, target_val)
+    } else {
+      stop(paste0("calibrate_method \"", calibrate_method, "\" not found."))
+    }
+
+    val
+  }
+
+
+  ## Calibrate PLHIV
   plhiv_aggr_var <- get_spectrum_aggr_var(spectrum_plhiv_calibration_level,
                                           spectrum_plhiv_calibration_strat)
 
   if(length(plhiv_aggr_var) > 0L) {
 
-    spectrum_calibration <- spectrum_calibration %>%
+    plhiv_target <- spectrum_calibration %>%
       dplyr::group_by_at(plhiv_aggr_var) %>%
-      dplyr::mutate(plhiv_calibration = sum(plhiv_spectrum) / sum(plhiv_raw)) %>%
-      dplyr::ungroup()
+      dplyr::summarise(plhiv_target = sum(plhiv_spectrum),
+                       .groups = "drop")
 
-  } else {
-    spectrum_calibration$plhiv_calibration <- 1.0
+    valmean_wide <- valmean_wide %>%
+      dplyr::left_join(plhiv_target, by = plhiv_aggr_var)
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::group_by_at(plhiv_aggr_var) %>%
+      dplyr::mutate(
+               plhiv = calibrate_one(plhiv,
+                                     prevalence,
+                                     population,
+                                     plhiv_target,
+                                     calibrate_method)
+             )
   }
 
+
+  ## Calibrate ART number
   artnum_aggr_var <- get_spectrum_aggr_var(spectrum_artnum_calibration_level,
                                            spectrum_artnum_calibration_strat)
 
   if(length(artnum_aggr_var) > 0L) {
 
-    spectrum_calibration <- spectrum_calibration %>%
+    artnum_target <- spectrum_calibration %>%
       dplyr::group_by_at(artnum_aggr_var) %>%
-      dplyr::mutate(art_current_calibration = sum(art_current_spectrum) / sum(art_current_raw)) %>%
-      dplyr::ungroup()
+      dplyr::summarise(artnum_target = sum(art_current_spectrum),
+                       .groups = "drop")
 
-  } else {
-    spectrum_calibration$art_current_calibration <- 1.0
+    valmean_wide <- valmean_wide %>%
+      dplyr::left_join(artnum_target, by = artnum_aggr_var)
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::group_by_at(artnum_aggr_var) %>%
+      dplyr::mutate(
+               art_current_residents = calibrate_one(art_current_residents,
+                                                     art_coverage,
+                                                     plhiv,
+                                                     artnum_target,
+                                                     calibrate_method),
+               untreated_plhiv_num = plhiv - art_current_residents
+             )
+
+    ## Calibrate number attending
+    ## Note: aggregation based off calibrated values for valmean_wide$art_current_residents
+
+    artattend_aggr_var <- get_spectrum_aggr_var(spectrum_artnum_calibration_level,
+                                                "sex_age_group")
+
+    artattend_target <- valmean_wide %>%
+      dplyr::group_by_at(artattend_aggr_var) %>%
+      dplyr::summarise(artattend_target = sum(art_current_residents),
+                       .groups = "drop")
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::left_join(artattend_target, by = artattend_aggr_var)
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::group_by_at(artattend_aggr_var) %>%
+      dplyr::mutate(
+               art_current = calibrate_proportional_one(art_current,
+                                                        artattend_target)
+             )
   }
 
-  aware_aggr_var <- get_spectrum_aggr_var(spectrum_aware_calibration_level,
-                                          spectrum_aware_calibration_strat)
-
-  if(length(aware_aggr_var) > 0L) {
-
-    spectrum_calibration <- spectrum_calibration %>%
-      dplyr::group_by_at(aware_aggr_var) %>%
-      dplyr::mutate(unaware_calibration = sum(unaware_spectrum) / sum(unaware_raw)) %>%
-      dplyr::ungroup()
-
-  } else {
-    spectrum_calibration$unaware_calibration <- 1.0
-  }
-
-
+  ## Calibrate infections
   infections_aggr_var <- get_spectrum_aggr_var(spectrum_infections_calibration_level,
                                                spectrum_infections_calibration_strat)
 
-  if (length(infections_aggr_var) > 0L) {
+  if(length(infections_aggr_var) > 0L) {
 
-    spectrum_calibration <- spectrum_calibration %>%
+    infections_target <- spectrum_calibration %>%
       dplyr::group_by_at(infections_aggr_var) %>%
-      dplyr::mutate(infections_calibration = dplyr::if_else(sum(infections_raw) == 0, 0, sum(infections_spectrum) / sum(infections_raw))) %>%
-      dplyr::ungroup()
+      dplyr::summarise(infections_target = sum(infections_spectrum),
+                       .groups = "drop")
 
-  } else {
-    spectrum_calibration$infections_calibration <- 1.0
+    valmean_wide <- valmean_wide %>%
+      dplyr::left_join(infections_target, by = infections_aggr_var)
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::group_by_at(infections_aggr_var) %>%
+      dplyr::mutate(
+               infections = calibrate_one(infections,
+                                          incidence,
+                                          population - plhiv,
+                                          infections_target,
+                                          calibrate_method)
+             )
   }
 
-  spectrum_calibration <- spectrum_calibration %>%
-    dplyr::mutate(plhiv_final = plhiv_raw * plhiv_calibration,
-                  art_current_final = art_current_raw * art_current_calibration,
-                  infections_final = infections_raw * infections_calibration)
+  ## Calibrate number unaware of HIV status
 
-  ## Will be NA if output_aware_plhiv = FALSE
-  spectrum_calibration$unaware_final <- spectrum_calibration$unaware_raw * spectrum_calibration$unaware_calibration
+  unaware_aggr_var <- get_spectrum_aggr_var(spectrum_aware_calibration_level,
+                                            spectrum_aware_calibration_strat)
+
+
+  if (naomi_mf$output_aware_plhiv & length(unaware_aggr_var) > 0L) {
+
+    unaware_target <- spectrum_calibration %>%
+      dplyr::group_by_at(unaware_aggr_var) %>%
+      dplyr::summarise(unaware_target = sum(unaware_spectrum),
+                       .groups = "drop")
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::left_join(unaware_target, by = unaware_aggr_var)
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::group_by_at(unaware_aggr_var) %>%
+      dplyr::mutate(
+               unaware_plhiv_num = calibrate_one(unaware_plhiv_num,
+                                                 unaware_plhiv_prop,
+                                                 plhiv - art_current_residents,
+                                                 unaware_target,
+                                                 calibrate_method)
+             )
+
+    valmean_wide <- valmean_wide %>%
+      dplyr::mutate(aware_plhiv_num = plhiv - unaware_plhiv_num)
+  } else {
+    valmean_wide$aware_plhiv_num <- NA_real_
+  }
+
 
 
   spectrum_calibration <- spectrum_calibration %>%
     dplyr::select(spectrum_region_code, sex, age_group, calendar_quarter,
                   population_spectrum, population_raw, population_calibration, population_final = population,
-                  plhiv_spectrum, plhiv_raw, plhiv_calibration, plhiv_final,
-                  art_current_spectrum, art_current_raw, art_current_calibration, art_current_final,
-                  unaware_spectrum, unaware_raw, unaware_calibration, unaware_final,
-                  infections_spectrum, infections_raw, infections_calibration, infections_final)
+                  plhiv_spectrum, plhiv_raw,
+                  art_current_spectrum, art_current_raw,
+                  unaware_spectrum, unaware_raw,
+                  infections_spectrum, infections_raw)
+
+  val_adj <- valmean_wide %>%
+    tidyr::pivot_longer(cols = c(population, plhiv, art_current_residents, art_current,
+                                 untreated_plhiv_num, unaware_plhiv_num, aware_plhiv_num,
+                                 infections),
+                        names_to = "indicator", values_to = "adjusted")
 
 
-  ## Calculate calibrated values at finest stratification (mf_model)
-
-  val_adj <- val %>%
-    dplyr::left_join(
-             spectrum_calibration %>%
-             dplyr::select(
-                      tidyselect::all_of(group_vars),
-                      plhiv = plhiv_calibration,
-                      art_current_residents = art_current_calibration,
-                      unaware_plhiv_num = unaware_calibration,
-                      infections = infections_calibration
-                    ) %>%
-             tidyr::pivot_longer(cols = c(plhiv, art_current_residents, unaware_plhiv_num, infections),
-                                 names_to = "indicator", values_to = "calibration"),
-             by = c("indicator", group_vars)
-           ) %>%
-    dplyr::mutate(adjusted = mean * calibration)
-
-  ## Logistic scaling adjustment
-  if (calibrate_method == "logistic") {
-    val_wide <- val_adj %>%
-      tidyr::pivot_wider(c(area_id, group_vars), names_from = indicator, values_from = c(mean, adjusted))
-
-    val_wide <- val_wide %>%
-      dplyr::mutate(age_coarse = dplyr::if_else(
-                                          age_group %in% c("Y000_004", "Y005_009", "Y010_014"),
-                                          "Y000_014", "Y015_999"))
-
-
-    calibrate_logistic_one <- function(numerator_vector,
-                                       denominator_vector,
-                                       denominator_new,
-                                       target_vector) {
-
-      target_val <- sum(target_vector)
-      logit_p_fine <- qlogis(numerator_vector / denominator_vector)
-      adjust_numerator <- function(theta, l, d) plogis(l + theta) * d
-      optfn <- function(theta) (sum(adjust_numerator(theta, logit_p_fine, denominator_new)) - target_val)^2
-      opt <- optimise(optfn, c(-10, 10), tol = .Machine$double.eps^0.5)
-
-      adjust_numerator(opt$minimum, logit_p_fine, denominator_new)
-    }
-
-
-
-    val_wide_adj <- val_wide %>%
-      dplyr::group_by_at(plhiv_aggr_var) %>%
-      dplyr::mutate(
-               adjusted_plhiv = calibrate_logistic_one(mean_plhiv,
-                                                       mean_population,
-                                                       mean_population,
-                                                       adjusted_plhiv)
-             ) %>%
-      dplyr::group_by_at(artnum_aggr_var) %>%
-      dplyr::mutate(
-               adjusted_art_current_residents =
-                 calibrate_logistic_one(mean_art_current_residents,
-                                        mean_plhiv,
-                                        adjusted_plhiv,
-                                        adjusted_art_current_residents)) %>%
-      dplyr::group_by_at(infections_aggr_var) %>%
-      dplyr::mutate(
-               adjusted_infections =
-                 calibrate_logistic_one(mean_infections,
-                                        mean_population - mean_plhiv,
-                                        mean_population - adjusted_plhiv,
-                                        adjusted_infections)
-             ) %>%
-      dplyr::ungroup()
-
-    if (naomi_mf$output_aware_plhiv) {
-
-      val_wide_adj <- val_wide_adj %>%
-        dplyr::group_by_at(aware_aggr_var) %>%
-        dplyr::mutate(
-                 adjusted_unaware_plhiv_num =
-                   calibrate_logistic_one(mean_unaware_plhiv_num,
-                                          mean_plhiv - mean_art_current_residents,
-                                          adjusted_plhiv - adjusted_art_current_residents,
-                                          adjusted_unaware_plhiv_num)
-               ) %>%
-        dplyr::ungroup()
-      
-    } else {
-      val_wide_adj$adjusted_unaware_plhiv_num <- NA_real_
-    }
-    
-    val_adj <- val_wide_adj %>%
-      dplyr::rename(plhiv = adjusted_plhiv,
-                    art_current_residents = adjusted_art_current_residents,
-                    unaware_plhiv_num = adjusted_unaware_plhiv_num,
-                    infections = adjusted_infections) %>%
-      tidyr::pivot_longer(c(plhiv, art_current_residents, unaware_plhiv_num, infections),
-                          names_to = "indicator", values_to = "adjusted") %>%
-      dplyr::select("area_id", tidyselect::all_of(group_vars), indicator, adjusted)
-  }
-
-  ## Aggregate adjusted fine stratification values
+  ## Aggregate adjusted fine stratification values to all Naomi aggregates
 
   .expand <- function(cq, ind) {
+
+    stopifnot(cq %in% val_adj$calendar_quarter)
+    stopifnot(ind %in% val_adj$indicator)
 
     byv <- c("area_id", "sex", "spectrum_region_code", "age_group")
     m <- dplyr::filter(val_adj, calendar_quarter == cq, indicator == ind)
@@ -1113,15 +1218,27 @@ calibrate_outputs <- function(output,
   }
 
   adj <- dplyr::bind_rows(
+                  .expand(naomi_mf$calendar_quarter1, "population"),
+                  .expand(naomi_mf$calendar_quarter2, "population"),
+                  .expand(naomi_mf$calendar_quarter3, "population"),
                   .expand(naomi_mf$calendar_quarter1, "plhiv"),
                   .expand(naomi_mf$calendar_quarter2, "plhiv"),
                   .expand(naomi_mf$calendar_quarter3, "plhiv"),
                   .expand(naomi_mf$calendar_quarter1, "art_current_residents"),
                   .expand(naomi_mf$calendar_quarter2, "art_current_residents"),
                   .expand(naomi_mf$calendar_quarter3, "art_current_residents"),
+                  .expand(naomi_mf$calendar_quarter1, "art_current"),
+                  .expand(naomi_mf$calendar_quarter2, "art_current"),
+                  .expand(naomi_mf$calendar_quarter3, "art_current"),
+                  .expand(naomi_mf$calendar_quarter1, "untreated_plhiv_num"),
+                  .expand(naomi_mf$calendar_quarter2, "untreated_plhiv_num"),
+                  .expand(naomi_mf$calendar_quarter3, "untreated_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter1, "unaware_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter2, "unaware_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter3, "unaware_plhiv_num"),
+                  .expand(naomi_mf$calendar_quarter1, "aware_plhiv_num"),
+                  .expand(naomi_mf$calendar_quarter2, "aware_plhiv_num"),
+                  .expand(naomi_mf$calendar_quarter3, "aware_plhiv_num"),
                   .expand(naomi_mf$calendar_quarter1, "infections"),
                   .expand(naomi_mf$calendar_quarter2, "infections"),
                   .expand(naomi_mf$calendar_quarter3, "infections")
@@ -1129,124 +1246,96 @@ calibrate_outputs <- function(output,
 
   byv <- c("indicator", "area_id", "sex", "age_group", "calendar_quarter")
 
-  adj <- dplyr::right_join(
-                  dplyr::select(indicators, tidyselect::all_of(byv), mean),
-                  dplyr::select(adj, tidyselect::all_of(byv), adjusted),
-                  by = byv
-                ) %>%
+  adj_counts <- dplyr::right_join(
+                         dplyr::select(indicators, tidyselect::all_of(byv), raw = mean),
+                         dplyr::select(adj, tidyselect::all_of(byv), adjusted),
+                         by = byv
+                       ) %>%
     dplyr::mutate(
-             ratio = dplyr::if_else(adjusted == 0, 0, adjusted / mean),
-             mean = NULL,
+             ratio = dplyr::if_else(adjusted == 0, 0, adjusted / raw),
+             raw = NULL,
              adjusted = NULL
-           ) %>%
-    tidyr::spread(indicator, ratio) %>%
-    dplyr::rename(plhiv_calib = plhiv,
-                  artnum_calib = art_current_residents,
-                  unaware_calib = unaware_plhiv_num,
-                  infections_calib = infections)
-
-  out <- indicators %>%
-    dplyr::left_join(adj, by = c("area_id", "sex", "age_group", "calendar_quarter")) %>%
-    dplyr::mutate(
-             calibration = dplyr::case_when(
-                                    indicator == "plhiv" ~ plhiv_calib,
-                                    indicator == "prevalence" ~ plhiv_calib,
-                                    indicator == "art_coverage" ~ artnum_calib / plhiv_calib,
-                                    indicator == "art_current_residents" ~ artnum_calib,
-                                    indicator == "art_current" ~ artnum_calib,
-                                    indicator == "infections" ~ infections_calib,
-                                    TRUE ~ 1.0),
-             mean = mean * calibration,
-             se = se * calibration,
-             median = median * calibration,
-             mode = mode * calibration,
-             lower = lower * calibration,
-             upper = upper * calibration
            )
 
-  out <- dplyr::select(out, names(output$indicators))
+  out <- indicators %>%
+    dplyr::left_join(adj_counts, by = byv) %>%
+    dplyr::mutate(
+             ratio = tidyr::replace_na(ratio, 1.0),
+             mean = mean * ratio,
+             se = se * ratio,
+             median = median * ratio,
+             mode = mode * ratio,
+             lower = lower * ratio,
+             upper = upper * ratio,
+             ratio = NULL
+           )
 
-  incidence_calibration <- out %>%
-    dplyr::filter(indicator %in% c("population", "plhiv", "infections", "incidence")) %>%
-    tidyr::pivot_wider(
-             id_cols = c(area_id, sex, age_group, calendar_quarter),
-             names_from = indicator,
-             values_from = mean
+  out <- dplyr::select(out, tidyselect::all_of(names(output$indicators)))
+
+
+  adj_props <- adj %>%
+    tidyr::pivot_wider(names_from = indicator, values_from = adjusted) %>%
+    dplyr::mutate(
+             prevalence = plhiv / population,
+             art_coverage = art_current_residents / plhiv,
+             aware_plhiv_prop = aware_plhiv_num / plhiv,
+             incidence = infections / (population - plhiv)
+           ) %>%
+    tidyr::pivot_longer(c(prevalence, art_coverage, aware_plhiv_prop, incidence),
+                        names_to = "indicator", values_to = "adjusted") %>%
+    dplyr::select(tidyselect::all_of(byv), adjusted) %>%
+    dplyr::left_join(
+             dplyr::select(indicators, tidyselect::all_of(byv), raw = mean),
+             by = byv
            ) %>%
     dplyr::mutate(
-             incidence_new = infections / (population - plhiv),
-             incidence_calibration = dplyr::if_else(incidence_new == 0, 0, incidence_new / incidence)
-           ) %>%
-    dplyr::select(area_id, sex, age_group, calendar_quarter, incidence_calibration)
+             log_odds = dplyr::if_else(adjusted == 0, 0, qlogis(adjusted) - qlogis(raw)),
+             raw = NULL,
+             adjusted = NULL
+           )
+
+  adjust_prop <- function(val, log_odds) {
+    idx <- !is.na(log_odds)
+    val[idx] <- plogis(qlogis(val[idx]) + log_odds[idx])
+    val
+  }
+
+  adjust_prop_se <- function(se, mean, log_odds) {
+    idx <- !is.na(log_odds)
+    val <- se
+    val[idx] <- se[idx] * exp(log_odds[idx]) / ((exp(log_odds[idx]) - 1) * mean[idx] + 1)^2
+    val
+  }
 
   out <- out %>%
-    dplyr::left_join(incidence_calibration,
-                     by = c("area_id", "sex", "age_group", "calendar_quarter")) %>%
+    dplyr::left_join(adj_props, by = byv) %>%
     dplyr::mutate(
-             calibration = dplyr::if_else(indicator == "incidence", incidence_calibration, 1.0),
-             mean = mean * calibration,
-             se = se * calibration,
-             median = median * calibration,
-             mode = mode * calibration,
-             lower = lower * calibration,
-             upper = upper * calibration
-           ) %>%
-    dplyr::select(names(output$indicators))
+             mean = adjust_prop(mean, log_odds),
+             se = adjust_prop_se(se, mean, log_odds),
+             median = adjust_prop(median, log_odds),
+             mode = adjust_prop(mode, log_odds),
+             lower = adjust_prop(lower, log_odds),
+             upper = adjust_prop(upper, log_odds),
+             log_odds = NULL
+           )
 
-
-  if (naomi_mf$output_aware_plhiv) {
-
-    aware_calibration <- out %>%
-      dplyr::filter(
-               indicator %in% c("plhiv", "unaware_plhiv_num", "aware_plhiv_prop", "aware_plhiv_num")
-             ) %>%
-      tidyr::pivot_wider(
-               id_cols = c(area_id, sex, age_group, calendar_quarter),
-               names_from = indicator,
-               values_from = mean
-             ) %>%
-      dplyr::mutate(
-               aware_num_new = plhiv - unaware_plhiv_num,
-               aware_prop_new = aware_num_new / plhiv,
-               aware_num_calibration = dplyr::if_else(aware_num_new == 0, 0, aware_num_new / aware_plhiv_num),
-               aware_prop_calibration = dplyr::if_else(aware_prop_new == 0, 0, aware_prop_new / aware_plhiv_prop)
-             ) %>%
-      dplyr::select(area_id, sex, age_group, calendar_quarter,
-                    aware_num_calibration, aware_prop_calibration)
-
-    out <- out %>%
-      dplyr::left_join(aware_calibration,
-                       by = c("area_id", "sex", "age_group", "calendar_quarter")) %>%
-      dplyr::mutate(
-               calibration = dplyr::case_when(indicator == "aware_plhiv_prop" ~ aware_prop_calibration,
-                                              indicator == "aware_plhiv_num" ~ aware_num_calibration,
-                                              TRUE ~ 1.0),
-               mean = mean * calibration,
-               se = se * calibration,
-               median = median * calibration,
-               mode = mode * calibration,
-               lower = lower * calibration,
-               upper = upper * calibration
-             ) %>%
-      dplyr::select(names(output$indicators))
-  }
+  out <- dplyr::select(out, tidyselect::all_of(names(output$indicators)))
 
   ## Save calibration options
 
-  calibration_options <- c(output$fit$calibration_options,
-                           list(spectrum_plhiv_calibration_level  = spectrum_plhiv_calibration_level,
-                                spectrum_plhiv_calibration_strat  = spectrum_plhiv_calibration_strat,
-                                spectrum_artnum_calibration_level = spectrum_artnum_calibration_level,
-                                spectrum_artnum_calibration_strat = spectrum_artnum_calibration_strat,
-                                spectrum_aware_calibration_level = spectrum_aware_calibration_level,
-                                spectrum_aware_calibration_strat = spectrum_aware_calibration_strat,
-                                spectrum_infections_calibration_level = spectrum_infections_calibration_level,
-                                spectrum_infections_calibration_strat = spectrum_infections_calibration_strat)
-                           )
+  calib_opts <- list(spectrum_plhiv_calibration_level = spectrum_plhiv_calibration_level,
+                     spectrum_plhiv_calibration_strat  = spectrum_plhiv_calibration_strat,
+                     spectrum_artnum_calibration_level = spectrum_artnum_calibration_level,
+                     spectrum_artnum_calibration_strat = spectrum_artnum_calibration_strat,
+                     spectrum_aware_calibration_level = spectrum_aware_calibration_level,
+                     spectrum_aware_calibration_strat = spectrum_aware_calibration_strat,
+                     spectrum_infections_calibration_level = spectrum_infections_calibration_level,
+                     spectrum_infections_calibration_strat = spectrum_infections_calibration_strat,
+                     calibrate_method = calibrate_method)
 
   output$indicators <- out
   output$fit$spectrum_calibration <- spectrum_calibration
-  output$fit$calibration_options <- calibration_options
+  output$fit$calibration_options[names(calib_opts)] <- calib_opts
 
   output
 }

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1098,8 +1098,7 @@ calibrate_outputs <- function(output,
                                                      art_coverage,
                                                      plhiv,
                                                      artnum_target,
-                                                     calibrate_method),
-               untreated_plhiv_num = plhiv - art_current_residents
+                                                     calibrate_method)
              )
 
     ## Calibrate number attending
@@ -1123,6 +1122,7 @@ calibrate_outputs <- function(output,
                                                         artattend_target)
              )
   }
+  valmean_wide$untreated_plhiv_num = valmean_wide$plhiv - valmean_wide$art_current_residents
 
   ## Calibrate infections
   infections_aggr_var <- get_spectrum_aggr_var(spectrum_infections_calibration_level,
@@ -1175,11 +1175,10 @@ calibrate_outputs <- function(output,
                                                  calibrate_method)
              )
 
-    valmean_wide <- valmean_wide %>%
-      dplyr::mutate(aware_plhiv_num = plhiv - unaware_plhiv_num)
-  } else {
-    valmean_wide$aware_plhiv_num <- NA_real_
   }
+
+  valmean_wide <- valmean_wide %>%
+    dplyr::mutate(aware_plhiv_num = plhiv - unaware_plhiv_num)
 
 
 

--- a/inst/datapack/datapack_indicator_mapping.csv
+++ b/inst/datapack/datapack_indicator_mapping.csv
@@ -11,4 +11,4 @@ anc_tested_neg,tAE7ZD7p9zu,PMTCT_STAT_SUBNAT.N.New.Neg.T_1,# Pregnant Women who 
 anc_tested_pos,tAE7ZD7p9zu,PMTCT_STAT_SUBNAT.N.New.Pos.T_1,# Pregnant Women who are newly tested and found HIV-positive at ANC1,TRUE
 art_current,xghQXueYJxu,TX_CURR_SUBNAT.T_1,Total # of PLHIV on ART,TRUE
 art_coverage,TX_CURR_SUBNAT.Rt.T_1,TX_CURR_SUBNAT.Rt.T_1,ART coverage,FALSE
-aware_plhiv_num,DIAGNOSED_SUBNAT.T_1,nF19GOjcnoD,Number of PLHIV aware of HIV positive status,TRUE
+aware_plhiv_num,nF19GOjcnoD,DIAGNOSED_SUBNAT.T_1,Number of PLHIV aware of HIV positive status,TRUE

--- a/inst/metadata/calibration_run_options.json
+++ b/inst/metadata/calibration_run_options.json
@@ -220,6 +220,7 @@
         {
           "name": "calibrate_method",
           "type": "select",
+          "value": "logistic",
           "required": true,
           "options": [
             {

--- a/man/calibrate_outputs.Rd
+++ b/man/calibrate_outputs.Rd
@@ -18,6 +18,81 @@ calibrate_outputs(
   calibrate_method = "logistic"
 )
 }
+\arguments{
+\item{output}{Naomi model output package produced by \code{\link[=output_package]{output_package()}}.}
+
+\item{naomi_mf}{Naomi model frame, objective of class \code{naomi_mf}.}
+
+\item{spectrum_plhiv_calibration_level}{Level to calibrate PLHIV, see details.}
+
+\item{spectrum_plhiv_calibration_strat}{Age/sex stratification to calibrate PLHIV, see details.}
+
+\item{spectrum_artnum_calibration_level}{Level to calibrate number on ART, see details.}
+
+\item{spectrum_artnum_calibration_strat}{Age/sex stratification to calibrate number on ART, see details.}
+
+\item{spectrum_aware_calibration_level}{Level to calibrate number aware of HIV positive status, see details.}
+
+\item{spectrum_aware_calibration_strat}{Age/sex stratification to calibrate number aware of HIV positive status, see details.}
+
+\item{spectrum_infections_calibration_level}{Level to calibrate number infections of HIV positive status, see details.}
+
+\item{spectrum_infections_calibration_strat}{Age/sex stratification to calibrate number infections of HIV positive status, see details.}
+
+\item{calibrate_method}{Calibration method, either \code{"logistic"} (default) or \code{"proportional"}.}
+}
 \description{
 Calibrate naomi model outputs
+}
+\details{
+The following indicators are calibrated:
+\itemize{
+\item \code{plhiv}
+\item \code{art_current_residents}
+\item \code{unaware_plhiv_num}
+\item \code{infections}
+\item \code{art_current} (attending)
+\item \code{aware_plhiv_num}
+\item \code{untreated_plhiv_num}
+\item \code{prevalence}
+\item \code{art_coverage}
+\item \code{aware_plhiv_prop}
+\item \code{incidence}
+}
+
+Steps in the calibration:
+\enumerate{
+\item Aggregate Spectrum totals to specified stratification by level/sex/age to
+calculate the target totals within each stratification.
+\item Adjust fine area/sex/age-group mean values to match targeted total using
+either "logistic" or "proportional" scaling.
+\item Aggregate revised mean count values to all stratifications of Naomi outputs.
+\item Calculate calibrated mean for proportion indicators.
+\item Adjust outputs for all statistics (mean, median, mode, se, range).
+\item Aggregate totals spectrum_calibration table.
+}
+
+The "logistic" scaling method converts fine counts to logit proportions, then
+uses numerical optimisation to solve the logit-scale adjustment to the fine
+district/sex/age proportions such that the adjusted proportions times the
+denominator sums to the target value.
+
+Calibration proceeds sequentially through the following indicators.
+\itemize{
+\item PLHIV
+\item Number of residents on ART
+\item Number unaware of HIV status
+\item Number of new infections
+\item Number of attending ANC by district
+}
+
+Calibration of a previous indicator may affect the denominator for the next
+indicator. This does not affect the calculation for proportional scaling,
+but will affect logistic scaling. Inconsistent selections for calibration
+levels or stratifications could result in a denominator smaller than a target
+numerator for a particular value. This will throw an error for logistic
+scaling methods.
+
+The number of attending ARG clients is always calibrated proportionally by
+sex and five-year age group to the number or residents attending.
 }

--- a/man/calibrate_outputs.Rd
+++ b/man/calibrate_outputs.Rd
@@ -14,7 +14,8 @@ calibrate_outputs(
   spectrum_aware_calibration_level,
   spectrum_aware_calibration_strat,
   spectrum_infections_calibration_level,
-  spectrum_infections_calibration_strat
+  spectrum_infections_calibration_strat,
+  calibrate_method = "logistic"
 )
 }
 \description{

--- a/man/scale_gmrf_precision.Rd
+++ b/man/scale_gmrf_precision.Rd
@@ -23,6 +23,6 @@ This function scales the precision matrix of a GMRF such that the geometric
 mean of the marginal variance is one.
 }
 \details{
-This implements the same thing as \code{\link[INLA:inla.scale.model]{INLA::inla.scale.model}}. The marginal
+This implements the same thing as \code{\link[INLA:scale.model]{INLA::inla.scale.model}}. The marginal
 variance of each connected component is one.
 }


### PR DESCRIPTION
This PR:

* Sets a default value for the new `calibrate_method` model option.
* Harmonises some aspects of the model output calibration step.
* Fixes an error in the Data Pack output metadata.