### PR TITLE
hotfix: remove calibrate_method from summary report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.3
+Version: 2.3.4
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # naomi 2.3.3
 
+* Hotfix: remove `option$calibrate_method` from summary report (naomi troubleshooting #76).
+
+# naomi 2.3.3
+
 * Update naomi summary report
 * Switch to brio for file reading to avoid encoding issues on windows
 

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -392,9 +392,7 @@ text <- tibble::tibble(prefix = c("Population calibration: ",
                                   "ART number calibration level: ", 
                                   "ART number calibration strata: ", 
                                   "New infections calibration level: ",
-                                  "New infections calibration strata: ", 
-                                  "Calibration method: "
-                                  
+                                  "New infections calibration strata: "
                                   ), 
                        source = c(calibration_options$spectrum_population_calibration,
                                   calibration_options$spectrum_plhiv_calibration_level,
@@ -404,8 +402,7 @@ text <- tibble::tibble(prefix = c("Population calibration: ",
                                   calibration_options$spectrum_artnum_calibration_level,
                                   calibration_options$spectrum_artnum_calibration_strat, 
                                   calibration_options$spectrum_infections_calibration_level,
-                                  calibration_options$spectrum_infections_calibration_strat, 
-                                  options$calibrate_method
+                                  calibration_options$spectrum_infections_calibration_strat
                                   ))
   
 


### PR DESCRIPTION
This addresses issue reported by Rob Glaubius on troubleshooting 76.

Open PR to kick off Build Kite. Will add more comments in a moment