### PR TITLE
restrict ART parameters if not T1 ART data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.5
+Version: 2.3.6
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# naomi 2.3.6
+
+* If ART data are not available at both times, do not estimate overall or district-level 
+  change in ART coverage. Previously this was only restricted if there were no ART at 
+  Time 2; not the case where ART at time 2 but not at time 1.
+* It no sex-stratified ART data from any source, do not estimate difference between adult 
+  female and male ART coverage.
+
 # naomi 2.3.5
 
 * Add PEPFAR Datim UID for Angola.

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -185,16 +185,24 @@ prepare_tmb_inputs <- function(naomi_data) {
 
   ## If no sex stratified ART coverage data, don't estimate spatial variation in
   ## sex odds ratio
-  if ( ! all(c("male", "female") %in% naomi_data$prev_dat$sex)) {
+  if ( ! all(c("male", "female") %in% naomi_data$artcov_dat$sex) &
+       ! all(c("male", "female") %in% naomi_data$artnum_t1_dat$sex) &
+       ! all(c("male", "female") %in% naomi_data$artnum_t2_dat$sex) ) {
     f_alpha_xs <- ~0
   } else {
     f_alpha_xs <- ~0 + area_idf
   }
 
   
-  ## If no t2 ART data, do not fit a change in ART coverage. Use logit difference
-  ## in ART coverage from Spectrum.
-  if(nrow(naomi_data$artnum_t2_dat) == 0) {
+  ## If no ART data at both time points, do not fit a change in ART coverage. Use
+  ## logit difference in ART coverage from Spectrum.
+  ## T1 ART data may be either survey or programme
+  ##
+
+  has_t1_art <- nrow(naomi_data$artcov_dat) > 0 | nrow(naomi_data$artnum_t1_dat) > 0
+  has_t2_art <- nrow(naomi_data$artnum_t2_dat) > 0
+  
+  if( !has_t1_art | !has_t2_art ) {
     f_alpha_t2 <- ~0
     f_alpha_xt <- ~0
     logit_alpha_t1t2_offset <- naomi_data$mf_model$logit_alpha_t1t2_offset


### PR DESCRIPTION
This address #207 to remove parameters for estimating change in ART coverage by district if ART data are not available at both time points.  This was previously implemented only if no T2 ART data were available.

This resolves convergence issues with Gambia (troubleshooting 21), where ART data are available at T2, but ART data are available at the time of the survey (2013).