### PR TITLE
don't interpolate ART if exact quarter provided

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.6
+Version: 2.3.7
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naomi 2.3.7
+
+* When selecting ART data in `artnum_mf()`, if exact ART quarter is found in the 
+  data, filter those data instead of interpolating. This is more efficient and 
+  avoids interpolation error if only a single quarter of data are uploaded.
+
 # naomi 2.3.6
 
 * If ART data are not available at both times, do not estimate overall or district-level 

--- a/R/model.R
+++ b/R/model.R
@@ -1223,7 +1223,10 @@ artnum_mf <- function(calendar_quarter, art_number, naomi_mf) {
       stop(paste("ART data multiply reported for some age/sex strata in areas:",
                  paste(unique(art_duplicated_check$model_area_id), collapse = ", ")))
     }
-    
+
+    if (out_quarter_id %in% dat$quarter_id) {
+      dat <- dplyr::filter(dat, quarter_id == out_quarter_id)
+    } else {
     dat <- dat %>%
       dplyr::group_by(area_id, sex, age_group) %>%
       dplyr::summarise(min_data_quarter = min(quarter_id),
@@ -1232,6 +1235,7 @@ artnum_mf <- function(calendar_quarter, art_number, naomi_mf) {
       dplyr::ungroup() %>%
       dplyr::filter(out_quarter_id > min_data_quarter - 4L,
                     out_quarter_id <= max_data_quarter)
+    }
 
     if (nrow(dat) == 0) {
       stop(t_("NO_ART_DATA_FOR_QUARTER",

--- a/tests/testthat/test-model-frame.R
+++ b/tests/testthat/test-model-frame.R
@@ -41,6 +41,13 @@ test_that("artnum_mf() throws errors for invalid inputs", {
   expect_error(artnum_mf(c("CY2016Q1", "CY2016Q2"), demo_art_number, "jibberish"))
 })
 
+test_that("artnum_mf() works with single quarter ART data", {
+  data_art_single_quarter <- dplyr::filter(demo_art_number, calendar_quarter == "CY2017Q4")
+  expect_equal(nrow(artnum_mf("CY2017Q4", data_art_single_quarter, a_naomi_mf)), 14L)
+})
+
+
+
 
 test_that("population calibration options", {
 


### PR DESCRIPTION
This addresses #214, which arises from troubleshooting-86 for Chad. If ART data for the exact quarter requested are uploaded, don't interpolate, just filter to those data.

It has a test!