### PR TITLE
Name all translator_register args

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,7 +8,9 @@ naomi_init_traduire <- function() {
   pattern <- sprintf("%s/{language}-{namespace}.json", root)
   languages <- c("en", "fr")
   namespaces <- "translation"
-  traduire::translator_register(NULL, languages[[1]], namespaces[[1]],
+  traduire::translator_register(resources = NULL,
+                                language = languages[[1]],
+                                default_namespace = namespaces[[1]],
                                 resource_pattern = pattern,
                                 namespaces = namespaces,
                                 fallback = "en",


### PR DESCRIPTION
Thanks @krisher1 for reporting this

We changed the options in `traduire` to hopefully be more extensible in the future. The result is that the args to `translator_register` need to be named.