### PR TITLE
Add file upload descriptions to metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.7
+Version: 2.3.8
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.3.8
+
+* Add description text for ADR upload to model output metadata.
+
 # naomi 2.3.7
 
 * When selecting ART data in `artnum_mf()`, if exact ART quarter is found in the 

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -147,9 +147,8 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
     calibration_path,
     metadata = list(
       areas = options$area_scope,
-      output_description = build_output_description(data, options),
-      summary_report_description = build_summary_report_description(data,
-                                                                    options)
+      output_description = build_output_description(options),
+      summary_report_description = build_summary_report_description(options)
   ))
 }
 
@@ -233,6 +232,14 @@ hintr_calibrate <- function(output, calibration_options,
   generate_output_summary_report(summary_report_path,
                                  spectrum_path,
                                  quiet = TRUE)
+
+  metadata <- output$metadata
+  if (is.null(metadata$output_description)) {
+    metadata$output_description <- build_output_description(calibration_data$info)
+  }
+  if (is.null(metadata$summary_report_description)) {
+    metadata$summary_report_description <- build_summary_report_description(calibration_data$info)
+  }
   build_hintr_output(output_path, spectrum_path,
                      coarse_output_path, summary_report_path,
                      calibration_path, output$metadata)
@@ -645,10 +652,27 @@ format_options <- function(options) {
   options
 }
 
-build_output_description <- function(data, options) {
-  "Outputs uploaded from Naomi web app"
+build_output_description <- function(options) {
+  build_description("Naomi output uploaded from Naomi web app", options)
 }
 
-build_summary_report_description <- function(data, options) {
-  "Report uploaded from Naomi web app"
+build_summary_report_description <- function(options) {
+  build_description("Naomi summary report uploaded from Naomi web app",
+                    options)
+}
+
+build_description <- function(type_text, options) {
+  write_options <- function(name, value) {
+    sprintf("%s - %s", name, value)
+  }
+  opt_text <- Map(write_options,
+      c(t_("OPTIONS_GENERAL_AREA_SCOPE_LABEL"),
+        t_("OPTIONS_GENERAL_AREA_LEVEL_LABEL"),
+        t_("OPTIONS_GENERAL_CALENDAR_QUARTER_T2_LABEL"),
+        t_("OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL")),
+      c(options[["area_scope"]],
+        options[["area_level"]],
+        options[["calendar_quarter_t2"]],
+        options[["calendar_quarter_t3"]]))
+  paste0(c(type_text, "", opt_text), collapse = "\n")
 }

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -646,9 +646,9 @@ format_options <- function(options) {
 }
 
 build_output_description <- function(data, options) {
-  "placeholder text"
+  "Outputs uploaded from Naomi web app"
 }
 
 build_summary_report_description <- function(data, options) {
-  "placeholder text"
+  "Report uploaded from Naomi web app"
 }

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -146,7 +146,10 @@ hintr_run_model <- function(data, options, output_path = tempfile(),
     summary_report_path,
     calibration_path,
     metadata = list(
-      areas = options$area_scope
+      areas = options$area_scope,
+      output_description = build_output_description(data, options),
+      summary_report_description = build_summary_report_description(data,
+                                                                    options)
   ))
 }
 
@@ -236,7 +239,7 @@ hintr_calibrate <- function(output, calibration_options,
 }
 
 validate_calibrate_options <- function(calibration_options) {
-  
+
   expected_options <- c("spectrum_plhiv_calibration_level",
                         "spectrum_plhiv_calibration_strat",
                         "spectrum_artnum_calibration_level",
@@ -256,7 +259,7 @@ validate_calibrate_options <- function(calibration_options) {
   if (!all(calibration_options[["calibrate_method"]] %in% c("logistic", "proportional"))) {
     stop(t_("calibrate_method must be either \"logistic\" or \"proportional\""))
   }
-    
+
   invisible(TRUE)
 }
 
@@ -640,4 +643,12 @@ format_options <- function(options) {
     options["anc_art_coverage_year2"] <- list(NULL)
 
   options
+}
+
+build_output_description <- function(data, options) {
+  "placeholder text"
+}
+
+build_summary_report_description <- function(data, options) {
+  "placeholder text"
 }

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -235,14 +235,16 @@ hintr_calibrate <- function(output, calibration_options,
 
   metadata <- output$metadata
   if (is.null(metadata$output_description)) {
-    metadata$output_description <- build_output_description(calibration_data$info)
+    metadata$output_description <- build_output_description(
+      yaml::yaml.load(calibration_data$info$options.yml))
   }
   if (is.null(metadata$summary_report_description)) {
-    metadata$summary_report_description <- build_summary_report_description(calibration_data$info)
+    metadata$summary_report_description <- build_summary_report_description(
+      yaml::yaml.load(calibration_data$info$options.yml))
   }
   build_hintr_output(output_path, spectrum_path,
                      coarse_output_path, summary_report_path,
-                     calibration_path, output$metadata)
+                     calibration_path, metadata)
 }
 
 validate_calibrate_options <- function(calibration_options) {

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -99,6 +99,10 @@ test_that("model can be run", {
 
   ## Metadata has been saved
   expect_equal(model_run$metadata$areas, "MWI_1_2_demo")
+  expect_type(model_run$metadata$output_description, "character")
+  expect_length(model_run$metadata$output_description, 1)
+  expect_type(model_run$metadata$summary_report_description, "character")
+  expect_length(model_run$metadata$summary_report_description, 1)
 
   ## Summary report has been generated
   expect_true(file.size(summary_report_path) > 2000)

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -939,9 +939,7 @@ test_that("validate_calibrate_options errors if required options are missing", {
 
 })
 
-test_that("model run can be calibrated", {
-
-  ## Calibration makes no modification of existing files.
+test_that("calibrating adds output descriptions when missing", {
   output_hash <- tools::md5sum(a_hintr_output$output_path)
   spectrum_hash <- tools::md5sum(a_hintr_output$spectrum_path)
   coarse_output_hash <- tools::md5sum(a_hintr_output$coarse_output_path)
@@ -966,7 +964,6 @@ test_that("model run can be calibrated", {
 
   expect_s3_class(calibrated_output, "hintr_output")
 
-  ## Descriptions are created during calibrate where they are missing
   expect_type(calibrated_output$metadata$output_description, "character")
   expect_length(calibrated_output$metadata$output_description, 1)
   expect_type(calibrated_output$metadata$summary_report_description,

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -538,6 +538,11 @@ test_that("model run can be calibrated", {
 
   ## metadata is unchanged
   expect_equal(calibrated_output$metadata, a_hintr_output$metadata)
+  expect_type(calibrated_output$metadata$output_description, "character")
+  expect_length(calibrated_output$metadata$output_description, 1)
+  expect_type(calibrated_output$metadata$summary_report_description,
+              "character")
+  expect_length(calibrated_output$metadata$summary_report_description, 1)
 
   ## Can calibrate multiple times
   calibration_options <- list(
@@ -932,4 +937,39 @@ test_that("validate_calibrate_options errors if required options are missing", {
     "calibrate_method" = "JIBBERISH")),
     paste0("calibrate_method must be either \"logistic\" or \"proportional\""))
 
+})
+
+test_that("model run can be calibrated", {
+
+  ## Calibration makes no modification of existing files.
+  output_hash <- tools::md5sum(a_hintr_output$output_path)
+  spectrum_hash <- tools::md5sum(a_hintr_output$spectrum_path)
+  coarse_output_hash <- tools::md5sum(a_hintr_output$coarse_output_path)
+  summary_report_hash <- tools::md5sum(a_hintr_output$summary_report_path)
+  calibration_hash <- tools::md5sum(a_hintr_output$calibration_path)
+
+  output_path <- tempfile()
+  spectrum_path <- tempfile(fileext = ".zip")
+  coarse_output_path <- tempfile(fileext = ".zip")
+  summary_report_path = tempfile(fileext = ".html")
+  calibration_path <- tempfile(fileext = ".rds")
+  output <- a_hintr_output
+  output$metadata$output_description <- NULL
+  output$metadata$summary_report_description <- NULL
+  calibrated_output <- hintr_calibrate(output,
+                                       a_hintr_calibration_options,
+                                       output_path,
+                                       spectrum_path,
+                                       coarse_output_path,
+                                       summary_report_path,
+                                       calibration_path)
+
+  expect_s3_class(calibrated_output, "hintr_output")
+
+  ## Descriptions are created during calibrate where they are missing
+  expect_type(calibrated_output$metadata$output_description, "character")
+  expect_length(calibrated_output$metadata$output_description, 1)
+  expect_type(calibrated_output$metadata$summary_report_description,
+              "character")
+  expect_length(calibrated_output$metadata$summary_report_description, 1)
 })


### PR DESCRIPTION
This text will eventually be used as the text which gets pushed to the ADR when a user uploads their model outputs.

The text is something which we think will be useful, but I expect another iteration of this after UNAIDS have seen this.

At the moment the values shown are the internal values e.g. id MWI instead of name shown in the options drop down Malawi. And calendar quarter shown as CY2020Q1 instead of March 2020 which is not ideal. The mapping of calendar quarter is fairly straightforward but of the area scope and level is more complicated - these mappings only exist in the geojson. And the code which extracts this info is in hintr. Couple of options I can think of
* We move geojson reading logic into naomi from hintr, and call this to map area scope and area level to human readable values
* We update to get `value` and `label` from model run i.e. front end sends us both bits of data instead of just the value

Both are a bit rubbish - any thoughts on that? I think we can do this in a separate PR though. I am keen to get this merged in as is as it is blocking front end atm.