### PR TITLE
ensure nonnegative log linear interpolation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.3.7
+Version: 2.3.8
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.3.8
+
+* Ensure that log interpolation is non-negative values only by inserting `pmax(..., 0)` 
+  in function `log_lin_approx()`. (NAOMI TROUBLESHOOTING #100)
+
 # naomi 2.3.7
 
 * When selecting ART data in `artnum_mf()`, if exact ART quarter is found in the 

--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -524,7 +524,7 @@ get_spec_aggr_interpolation <- function(spec_aggr, calendar_quarter_out) {
 }
 
 log_lin_approx <- function(x, y, xout, replace_na_value = 0){
-  v <- exp(stats::approx(x, log(y), xout)$y)
+  v <- exp(stats::approx(x, log(pmax(y, 0)), xout)$y)
   v <- tidyr::replace_na(v, replace_na_value)
   v
 }


### PR DESCRIPTION
Ensure that arguments are non-negative for log-linear interpolation in function `log_lin_approx()`.  

This addresses naomi troubleshooting 100 where a numerical discrepancy resulted in slightly more (order of 0.0001) number on ART than number PLHIV resulting in negative untreated population from Spectrum PJNZ.
