### PR TITLE
manually avoid write_datapack_csv() warning when fitting with zone de…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.4.0
+Version: 2.4.1
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.4.1
+
+* Manually skip 'PSNU not found warning' in `write_datapack_csv()` when running `hintr_run_model()` with zone-level demo data. This occurs because the demo data have ISO3 = `MWI` for which the PSNU level is 3, but demo zone-level model fits are only applied to levels 0:2. A better solution would be to change the ISO3 for the demo data to something artificial, but this requires relaxing some validation in the user interface first.
+
 # naomi 2.4.0
 
 * Add demo datasets for subnational Spectrum files for three Malawi regions (Northern, Central, Southern).

--- a/R/pepfar-datapack.R
+++ b/R/pepfar-datapack.R
@@ -51,7 +51,14 @@ write_datapack_csv <- function(naomi_output,
   }
 
   if (is.null(psnu_level) || !psnu_level %in% naomi_output$meta_area$area_level) {
-    warning("PSNU level ", psnu_level, " not included in model outputs.")
+
+    ## If using the demo data, don't print this warning.
+    ## The demo data only contain levels 0:2, but have ISO3 = "MWI", for which psnu_level = 3.
+    ## A better way to handle this is to change the ISO3 for the demo data to an artificial
+    ## code. However, some hint validation needs to be relaxed to enable this.
+    if (!("MWI_2_5_demo" %in% naomi_output$meta_area$area_id && setequal(0:2, naomi_output$meta_area$area_level))) {
+      warning("PSNU level ", psnu_level, " not included in model outputs.")
+    }
   }
 
   if (is.null(calendar_quarter)) {


### PR DESCRIPTION
See branch name for description.

Quite a manually solution. A better solution is to change the ISO3 for the demo data to an artificial code. However, some hint validation needs to be relaxed first to enable this.