### PR TITLE
Include parent area id in response from time series

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.5.2
+Version: 2.5.3
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.5.3
+
+* Includ `parent_area_id` in input time series function outputs
+
 # naomi 2.5.2
 
 * Add function `get_plot_type_label_and_description` to get label and description for each input time series plot types.

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -70,7 +70,8 @@ prepare_input_time_series_art <- function(art, shape) {
   ## Shape data for plot
   art_plot_data <- art_long %>%
     dplyr::left_join(areas, by = "area_id" ) %>%
-    dplyr::group_by(area_id, area_name, area_level_label, area_level, time_step, time_period) %>%
+    dplyr::group_by(area_id, area_name, area_level_label, area_level,
+                    parent_area_id, time_step, time_period) %>%
     dplyr::summarise(
       art_total = sum(art_current, na.rm = TRUE),
       art_adult_f = sum(art_current * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = TRUE),
@@ -154,7 +155,7 @@ prepare_input_time_series_anc <- function(anc, shape) {
   ## Shape data for plot
   anc_plot_data <- anc_long %>%
     dplyr::left_join(areas %>% dplyr::select(area_id, area_name,area_level,
-                                             area_level_label),
+                                             area_level_label, parent_area_id),
                      by = "area_id") %>%
     dplyr::mutate(
       anc_total_pos = anc_known_pos + anc_tested_pos,
@@ -163,9 +164,10 @@ prepare_input_time_series_anc <- function(anc, shape) {
       anc_art_among_known = anc_already_art / anc_known_pos,
       anc_art_coverage = anc_already_art / anc_total_pos
     ) %>%
-    dplyr::select(area_id, area_name, area_level, area_level_label, age_group,
-                  time_period, time_step, anc_clients, anc_prevalence,
-                  anc_known_pos, anc_art_coverage) %>%
+    dplyr::select(area_id, area_name, area_level, area_level_label,
+                  parent_area_id, age_group, time_period, time_step,
+                  anc_clients, anc_prevalence, anc_known_pos,
+                  anc_art_coverage) %>%
     tidyr::pivot_longer(cols = dplyr::starts_with("anc"),
                         names_to = "plot",
                         values_to = "value")

--- a/tests/testthat/test-input-time-series.R
+++ b/tests/testthat/test-input-time-series.R
@@ -4,8 +4,9 @@ test_that("data can be formatted for ART input time series", {
 
   expect_true(nrow(data) > 100) ## Check that we have read out some data
   expect_setequal(colnames(data),
-                  c("area_id", "area_name", "area_level_label","area_level",
-                    "time_step", "time_period", "plot", "value"))
+                  c("area_id", "area_name", "area_level_label", "area_level",
+                    "parent_area_id", "time_step", "time_period", "plot",
+                    "value"))
 
   # Time period has correct format
   expect_setequal(data$time_step, "annual")
@@ -18,7 +19,8 @@ test_that("data can be formatted for ANC input time series", {
   expect_true(nrow(data) > 100) ## Check that we have read out some data
   expect_setequal(colnames(data),
                   c("area_id", "area_name", "area_level", "area_level_label",
-                    "age_group", "time_period", "time_step", "plot", "value"))
+                    "parent_area_id", "age_group", "time_period", "time_step",
+                    "plot", "value"))
 
   # Time period has correct format
   expect_setequal(data$time_step, "annual")


### PR DESCRIPTION
This is so that in hintr we can construct the hierarchy for returning to the front end

This is better than doing it in hintr separately as it means we can avoid reading the shape file twice and means the hierarchy is already filtered to the level in the available ART/ANC data