### PR TITLE
add argument output_package(..., na.rm = FALSE) for debugging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.5.3
+Version: 2.5.4
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.5.5
+
+* Add argument `na.rm=` to `output_package()` to allow calculation of quantiles if there are missing values in the simulation. Default is `na.rm = FALSE` and `na.rm = TRUE` is to be used for debugging purposes only. Cases where missing values occur will usually indicate very poor model fits and issues that need to be addressed.
+
 # naomi 2.5.3
 
 * Include `parent_area_id` and `area_sort_order` in input time series function outputs

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -20,7 +20,7 @@ get_meta_indicator <- function() {
 
 
 
-add_stats <- function(df, mode = NULL, sample = NULL, prefix = ""){
+add_stats <- function(df, mode = NULL, sample = NULL, prefix = "", na.rm = FALSE){
 
   v <- df
 
@@ -31,9 +31,11 @@ add_stats <- function(df, mode = NULL, sample = NULL, prefix = ""){
   }
 
   if(!is.null(sample)) {
-    qtl <- apply(sample, 1, stats::quantile, c(0.5, 0.025, 0.975), names = FALSE)
-    v[[paste0(prefix, "mean")]] <- rowMeans(sample)
-    v[[paste0(prefix, "se")]] <- sqrt(rowSums((sample - v[[paste0(prefix, "mean")]])^2) / (max(ncol(sample), 2) - 1))
+    qtl <- apply(sample, 1, stats::quantile, c(0.5, 0.025, 0.975), names = FALSE, na.rm = na.rm)
+    v[[paste0(prefix, "mean")]] <- rowMeans(sample, na.rm = na.rm)
+    rss <- rowSums((sample - v[[paste0(prefix, "mean")]])^2, na.rm = na.rm)
+    ndenom <- pmax(rowSums(!is.na(sample)), 2) - 1
+    v[[paste0(prefix, "se")]] <- sqrt(rss / ndenom)
     v[[paste0(prefix, "median")]] <- qtl[1,]
     v[[paste0(prefix, "lower")]] <- qtl[2,]
     v[[paste0(prefix, "upper")]] <- qtl[3,]
@@ -45,7 +47,7 @@ add_stats <- function(df, mode = NULL, sample = NULL, prefix = ""){
 }
 
 
-extract_indicators <- function(naomi_fit, naomi_mf) {
+extract_indicators <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
 
   get_est <- function(varname,
                       indicator,
@@ -58,9 +60,9 @@ extract_indicators <- function(naomi_fit, naomi_mf) {
 
     tryCatch(
       if(!is.null(naomi_fit$sample)) {
-        v <- add_stats(v, naomi_fit$mode[[varname]], naomi_fit$sample[[varname]])
+        v <- add_stats(v, naomi_fit$mode[[varname]], naomi_fit$sample[[varname]], na.rm = na.rm)
       } else {
-        v <- add_stats(v, naomi_fit$mode[[varname]])
+        v <- add_stats(v, naomi_fit$mode[[varname]], na.rm = na.rm)
       },
       "error" = function(e) {
         stop(t_("EXTRACT_INDICATORS_SIMULATE_ERROR",
@@ -185,7 +187,7 @@ extract_indicators <- function(naomi_fit, naomi_mf) {
                 calendar_quarter, indicator, mean, se, median, mode, lower, upper)
 }
 
-extract_art_attendance <- function(naomi_fit, naomi_mf) {
+extract_art_attendance <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
 
   mode <- naomi_fit$mode
 
@@ -268,14 +270,14 @@ extract_art_attendance <- function(naomi_fit, naomi_mf) {
   v$attend_out_idx <- NULL
 
   v_t1 <- dplyr::mutate(v, calendar_quarter = naomi_mf$calendar_quarter1)
-  v_t1 <- add_stats(v_t1, m_artattend_ij_t1, s_artattend_ij_t1, "artnum_")
-  v_t1 <- add_stats(v_t1, m_prop_residents_t1, s_prop_residents_t1, "prop_residents_")
-  v_t1 <- add_stats(v_t1, m_prop_attendees_t1, s_prop_attendees_t1, "prop_attendees_")
+  v_t1 <- add_stats(v_t1, m_artattend_ij_t1, s_artattend_ij_t1, "artnum_", na.rm = na.rm)
+  v_t1 <- add_stats(v_t1, m_prop_residents_t1, s_prop_residents_t1, "prop_residents_", na.rm = na.rm)
+  v_t1 <- add_stats(v_t1, m_prop_attendees_t1, s_prop_attendees_t1, "prop_attendees_", na.rm = na.rm)
 
   v_t2 <- dplyr::mutate(v, calendar_quarter = naomi_mf$calendar_quarter2)
-  v_t2 <- add_stats(v_t2, m_artattend_ij_t2, s_artattend_ij_t2, "artnum_")
-  v_t2 <- add_stats(v_t2, m_prop_residents_t2, s_prop_residents_t2, "prop_residents_")
-  v_t2 <- add_stats(v_t2, m_prop_attendees_t2, s_prop_attendees_t2, "prop_attendees_")
+  v_t2 <- add_stats(v_t2, m_artattend_ij_t2, s_artattend_ij_t2, "artnum_", na.rm = na.rm)
+  v_t2 <- add_stats(v_t2, m_prop_residents_t2, s_prop_residents_t2, "prop_residents_", na.rm = na.rm)
+  v_t2 <- add_stats(v_t2, m_prop_attendees_t2, s_prop_attendees_t2, "prop_attendees_", na.rm = na.rm)
 
   dplyr::bind_rows(v_t1, v_t2)
 }
@@ -285,14 +287,25 @@ extract_art_attendance <- function(naomi_fit, naomi_mf) {
 #'
 #' @param naomi_fit Fitted naomi model
 #' @param naomi_mf Naomi model frame
+#' @param na.rm Whether to remove NA values when calculating summary statistics, default FALSE
 #'
 #' @return List containing output indicators and metadata.
+#'
+#' @details
+#'
+#' The argument `na.rm = TRUE` allows the output package to be
+#' produced when there are errors due to missing values when
+#' generating outputs. This is only for debugging purposes to
+#' review results when there are errors. `NA` values in
+#' simulated model results typically mean poor model fit or
+#' non-convergence that needs to be addressed.
+#' 
 #' @export
-output_package <- function(naomi_fit, naomi_mf) {
+output_package <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
 
-  indicators <- extract_indicators(naomi_fit, naomi_mf)
+  indicators <- extract_indicators(naomi_fit, naomi_mf, na.rm = na.rm)
 
-  art_attendance <- extract_art_attendance(naomi_fit, naomi_mf)
+  art_attendance <- extract_art_attendance(naomi_fit, naomi_mf, na.rm = na.rm)
 
   meta_area <- naomi_mf$areas %>%
     dplyr::filter(area_id %in% unique(naomi_mf$mf_out$area_id)) %>%

--- a/man/output_package.Rd
+++ b/man/output_package.Rd
@@ -4,16 +4,26 @@
 \alias{output_package}
 \title{Build output package from fit}
 \usage{
-output_package(naomi_fit, naomi_mf)
+output_package(naomi_fit, naomi_mf, na.rm = FALSE)
 }
 \arguments{
 \item{naomi_fit}{Fitted naomi model}
 
 \item{naomi_mf}{Naomi model frame}
+
+\item{na.rm}{Whether to remove NA values when calculating summary statistics, default FALSE}
 }
 \value{
 List containing output indicators and metadata.
 }
 \description{
 Build output package from fit
+}
+\details{
+The argument \code{na.rm = TRUE} allows the output package to be
+produced when there are errors due to missing values when
+generating outputs. This is only for debugging purposes to
+review results when there are errors. \code{NA} values in
+simulated model results typically mean poor model fit or
+non-convergence that needs to be addressed.
 }

--- a/man/scale_gmrf_precision.Rd
+++ b/man/scale_gmrf_precision.Rd
@@ -23,6 +23,6 @@ This function scales the precision matrix of a GMRF such that the geometric
 mean of the marginal variance is one.
 }
 \details{
-This implements the same thing as \code{\link[INLA:inla.scale.model]{INLA::inla.scale.model}}. The marginal
+This implements the same thing as \code{\link[INLA:scale.model]{INLA::inla.scale.model}}. The marginal
 variance of each connected component is one.
 }


### PR DESCRIPTION
This PR adds an argument `na.rm = ` to the function `output_package(...)`.  If `na.rm = TRUE`, the model will remove any NA values to complete calculation of summary statistics and produce the output package.

This bypasses the error:
```
> out_raw <- output_package(zaf_fit, zaf_data)
Error in value[[3L]](cond) : 
  Error simulating output for indicator: anc_plhiv_t3_out. Please contact support for troubleshooting.
```

This is intended for debugging and troubleshooting use only because it can be useful to produce the full output package to examine results and see where things look crazy. It is not intended to be deployed in production use because `NA` values usually indicate non-convergence or poor fit that needs to be addressed.

