### PR TITLE
update default estimates and projections quarter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.5.11
+
+* Update defaults for current estimates period to `CY2021Q4` (December 2021) and short-term projection quarter to `CY2022Q3` (September 2022).
+
 # naomi 2.5.10
 
 * Change viral load indicators to `vl_tested_12mos` and `vl_suppressed_12mos` to specify that indicators are reported for the previous 12 months even if reporting period is quarterly.

--- a/inst/metadata/general_run_options.json
+++ b/inst/metadata/general_run_options.json
@@ -36,7 +36,7 @@
           "type": "select",
           "options":
             <+calendar_quarter_t2_options+>,
-          "value": "CY2020Q4",
+          "value": "CY2021Q4",
           "required": true
         }
       ]
@@ -47,7 +47,7 @@
         {
           "name": "calendar_quarter_t3",
           "type": "select",
-          "value": "CY2021Q3",
+          "value": "CY2022Q3",
           "helpText": "t_(OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP)",
           "required": true,
           "options": [
@@ -99,6 +99,22 @@
               "id": "CY2022Q4",
               "label": "t_(MONTH_DECEMBER) 2022"
             }
+            {
+              "id": "CY2023Q1",
+              "label": "t_(MONTH_MARCH) 2023"
+            },
+            {
+              "id": "CY2023Q2",
+              "label": "t_(MONTH_JUNE) 2023"
+            },
+            {
+              "id": "CY2023Q3",
+              "label": "t_(MONTH_SEPTEMBER) 2023"
+            },
+            {
+              "id": "CY2023Q4",
+              "label": "t_(MONTH_DECEMBER) 2023"
+            }	      
           ]
         }
       ]


### PR DESCRIPTION
Update defaults for current estimates period to `CY2021Q4` (December 2021) and short-term projection quarter to `CY2022Q3` (September 2022).