### PR TITLE
Remove unnecessary text in tooltip

### DIFF
--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -90,7 +90,7 @@
     "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_LABEL": "Survey design effect - Proportion recently infected",
     "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_HELP": "Approximate DEFF to scale effective sample size for survey for proportion recently infected amongst HIV positive",
     "OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL": "Calendar quarter to generate short-term projection",
-    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Calendar quarter to generate short-term projection. Must be after calendar quarter to generate estimates.",
+    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Must be after calendar quarter to generate estimates.",
     "MONTH_MARCH": "March",
     "MONTH_JUNE": "June",
     "MONTH_SEPTEMBER": "September",

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -90,7 +90,7 @@
     "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_LABEL": "Enquête design éffet - Proportion de personnes récemment infectées",
     "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_HELP": "DEFF approximatif pour ajuster la taille effective de l'échantillon de l'enquête sur la proportion récemment infectée parmi les séropositifs",
     "OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL": "Trimestre calendaire pour générer une projection à court terme",
-    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Trimestre calendaire pour générer une projection à court terme. Doit être après le trimestre calendaire pour générer des estimations",
+    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Doit être après le trimestre calendaire pour générer des estimations",
     "MONTH_MARCH": "Mars",
     "MONTH_JUNE": "Juin",
     "MONTH_SEPTEMBER": "Septembre",

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -141,7 +141,7 @@
     "OPTIONS_NO_LABEL": "Não",
     "OPTIONS_OUTPUT_DESCRIPTION": "Opções para controlar os resultados do modelo descarregado",
     "OPTIONS_OUTPUT_LABEL": "Opções de saída",
-    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Trimestre do calendário para gerar projeções de curto prazo. Deve ser após o trimestre do calendário para gerar estimativas.",
+    "OPTIONS_OUTPUT_PROJECTION_QUARTER_HELP": "Deve ser após o trimestre do calendário para gerar estimativas.",
     "OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL": "Trimestre do calendário para gerar projeções de curto prazo",
     "OPTIONS_POPULATION_CALIBRATION_DESCRIPTION": "Opções para calibrar de acordo com o tamanho da população no Spectrum. Em caso de ficheiro Spectrum nacional, as opções 'Nacional' e 'Subnacional' apresentarão o mesmo resultado. A calibração de acordo com a população no Spectrum é concluída antes do ajuste do modelo.",
     "OPTIONS_POPULATION_CALIBRATION_LABEL": "Calibração da população",


### PR DESCRIPTION
Feedback from user session, the first sentence in the tooltip is not needed.
![Screenshot_20211118_144137](https://user-images.githubusercontent.com/39248272/142436653-060b3b43-44dc-4b33-bbd4-d6465c8d9a64.png)

Another comment was on the number of survey options we show (option "Calendar quarter at midpoint of survey"), this is controlled from hintr but it hardcoded to show all quarters from 2010 to now. Should we reduce the number shown? Same for the "Calendar quarter to generate estimates"?