### PR TITLE
bump eppasm dependency to v0.5.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.5.17
+Version: 2.5.18
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",
@@ -24,7 +24,7 @@ Imports:
     brio,
     data.tree,
     dplyr,
-    eppasm (>= 0.5.9),
+    eppasm (>= 0.5.11),
     first90 (>= 1.5.1),
     forcats,
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.5.18
+
+* Update EPP-ASM dependency to v0.5.11 with patch for reading version of .DP file (troubleshooting #2022-42).
+
 # naomi 2.5.17
 
 * Update first90 package dependency to v1.5.1 for 2022 estimates.


### PR DESCRIPTION
This increased dependency for EPP-ASM to v0.5.11, which has a patch for parsing .DP file (troubleshooting #2022-42 for Uganda using Spectrum 6.1).



