### PR TITLE
remove non-outputted indicators from meta_indicator table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.6
+Version: 2.6.7
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.7
+
+* Remove non-outputted indicators from `meta_indicator` table in the output package.
+
 # naomi 2.6.6
 
 * Add new infections output to PEPFAR data pack export.

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -334,13 +334,17 @@ output_package <- function(naomi_fit, naomi_data, na.rm = FALSE) {
   fit$data_options <- naomi_data$data_options
   fit$calibration_options <- naomi_data$calibration_options
   fit$spectrum_calibration <- naomi_data$spectrum_calibration
+
+  meta_indicator <- get_meta_indicator()
+  meta_indicator <- dplyr::filter(meta_indicator, indicator %in% indicators$indicator)
+                                     
   val <- list(
     indicators = indicators,
     art_attendance = art_attendance,
     meta_area = meta_area,
     meta_age_group = meta_age_group,
     meta_period = meta_period,
-    meta_indicator = get_meta_indicator(),
+    meta_indicator = meta_indicator,
     fit = fit
   )
 

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -497,3 +497,8 @@ test_that("navigator checklist returns results for uncalibrated model output", {
 
   expect_true(checklist_adj$TrueFalse[checklist_adj$NaomiCheckPermPrimKey == "Cal_Population"])  
 })
+
+test_that("meta_indicator table contains same indicators as outputs", {
+  expect_setequal(a_output_full$meta_indicator$indicator,
+                  a_output_full$indicators$indicator)
+})


### PR DESCRIPTION
This PR removes non-outputted indicators from the `meta_indicator` table in the output package.  This addresses issues reported by John Stover that the Spectrum ratio indicators meta data were being written into the output package.