### PR TITLE
require eppasm v0.5.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.7
+Version: 2.6.8
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",
@@ -24,7 +24,7 @@ Imports:
     brio,
     data.tree,
     dplyr,
-    eppasm (>= 0.5.11),
+    eppasm (>= 0.5.12),
     first90 (>= 1.5.1),
     forcats,
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.8
+
+* Require `eppasm` v0.5.12 to avoid divide-by-zero in model computations (troubleshooting #2022-51).
+
 # naomi 2.6.7
 
 * Increase threshold to trigger warning for HIV prevalence in naomi outputs.


### PR DESCRIPTION
Require eppasm 0.5.12 to address issue with divide by 0 in ART eligibility in Kenya Nairobi file (troubleshooting #2022-51)