### PR TITLE
use calibrated population as prevalence denominator (troubleshooting #2022-73)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # naomi 2.6.9
 
-* Switch plot ordering to show HIV prevalence first
+* Switch plot ordering to show HIV prevalence first.
+* Patch logic error in calibration table: use calibrated population (done pre model fitting) as denominator for raw prevalence denominator (troublshooting #2022-73)
 
 # naomi 2.6.8
 


### PR DESCRIPTION
This PR fixes an error in the prevalence calculation shown in the calibration plot. It was discovered while interrogating @osymandius issue with Mozambique (troubleshooting 2022-73). It turned out there was no issue with the model fit, just the calibration plots showing the wrong data.

I suggest pulling this in with v2.6.9 in #297 currently pending. But also happy to make this a separate merge to master.