### PR TITLE
Revert indicator sort order change to use population first

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.10
+Version: 2.6.11
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.6.11
 
-* Revert plot ordering change made in 2.6.9 in favour of changing the default selected to HIV prevalence from hintr
+* Revert plot ordering change made in 2.6.9 in favour of changing the default selected to HIV prevalence from hintr.
 
 # naomi 2.6.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# 2.6.10
+# naomi 2.6.11
+
+* Revert plot ordering change made in 2.6.9 in favour of changing the default selected to HIV prevalence from hintr
+
+# naomi 2.6.10
 
 * MOZ `area_id` in `inst/datapack/datapack_psnu_area_id_map.csv` to new area hierarchy with separate Maputo provinces at admin-2.
 

--- a/inst/metadata/meta_indicator.csv
+++ b/inst/metadata/meta_indicator.csv
@@ -1,6 +1,6 @@
 indicator,indicator_label,description,parameter,indicator_sort_order,anc_indicator,format,scale
-population,t_(POPULATION),t_(INDICATOR_LABEL_POPULATION),population_out,2,FALSE,,
-prevalence,t_(HIV_PREVALENCE),t_(INDICATOR_LABEL_PREVALENCE),rho_out,1,FALSE,,
+population,t_(POPULATION),t_(INDICATOR_LABEL_POPULATION),population_out,1,FALSE,,
+prevalence,t_(HIV_PREVALENCE),t_(INDICATOR_LABEL_PREVALENCE),rho_out,2,FALSE,,
 plhiv,t_(PLHIV),t_(INDICATOR_LABEL_PLHIV),plhiv_out,3,FALSE,,
 art_coverage,t_(ART_COVERAGE),t_(INDICATOR_LABEL_ART_COVERAGE),alpha_out,4,FALSE,,
 art_current_residents,t_(ART_NUMBER_RESIDENTS),t_(INDICATOR_LABEL_ART_NUM_RESIDENTS),artnum_out,5,FALSE,,


### PR DESCRIPTION
What we ultimately want is in calibrate bar chart to have HIV prevalence as default selected item. At first I thought this always chose the first item from the drop down where ordering is controlled by `indicator_sort_order` after making this change and deploying we saw that `population` was still default selected item even though it was 2nd in order. After looking more closely there is some separate metadata in hintr to control the default selected item. So let's revert this and make the change in hintr.