### PR TITLE
remove PEPFAR Data Pack CSV from coarse download (troubleshooting #2022-81)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.11
+Version: 2.6.12
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.12
+
+* Do not save the PEPFAR Data Pack CSV for coarse age output package because the five-year age group results are not included.
+
 # naomi 2.6.11
 
 * Revert plot ordering change made in 2.6.9 in favour of changing the default selected to HIV prevalence from hintr.

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -695,7 +695,7 @@ save_output_coarse_age_groups <- function(path, naomi_output,
   save_output(basename(path), dirname(path), naomi_output_sub,
               overwrite = overwrite, with_labels = TRUE,
               boundary_format = "geojson", single_csv = FALSE,
-              export_datapack = TRUE)
+              export_datapack = FALSE)
 }
 
 save_output_spectrum <- function(path, naomi_output, overwrite = FALSE) {

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -82,7 +82,6 @@ test_that("coarse age group download can be created", {
     file_list$Name,
     c("boundaries.geojson", "indicators.csv", "art_attendance.csv",
       "meta_age_group.csv", "meta_area.csv", "meta_indicator.csv", "meta_period.csv",
-      "pepfar_datapack_indicators_2022.csv",
       "info/", info_names, "info/unaids_navigator_checklist.csv",
       "fit/", "fit/spectrum_calibration.csv",
       "fit/model_options.yml",

--- a/vignettes_src/hintr-example.R
+++ b/vignettes_src/hintr-example.R
@@ -76,6 +76,8 @@ hintr_paths <- hintr_run_model(hintr_data, hintr_options)
 calibrated_paths <- hintr_calibrate(hintr_paths, calibration_options)
 spectrum_download <- hintr_prepare_spectrum_download(calibrated_paths)
 
+coarse_download <- hintr_prepare_coarse_age_group_download(calibrated_paths)
+
 #' TO DO: add summary report download
 
 #' Read output package and generate datapack export


### PR DESCRIPTION
John noticed correctly that the coarse age group results download does not have a complete PEPFAR Data Pack output CSV. This is because the five-year age groups are removed from the results before the Data Pack CSV is produced.

The resolution to this is simply to remove the Data Pack CSV from the coarse age group results download so that users don't inadvertently try to use it.
