### PR TITLE
patch duplicate CLHIV projection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.15
+Version: 2.6.16
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.6.16
 
-* Bug fix: remove duplicate addition of CLHIV in T2 projection arising from paediatric incidence.
+* Bug fix: remove duplicate addition of CLHIV in T2 projection arising from paediatric incidence. This was introduced in v2.6.0 when paediatric new infections were added to the outputs.
 
 # naomi 2.6.15
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.16
+
+* Bug fix: remove duplicate addition of CLHIV in T2 projection arising from paediatric incidence.
+
 # naomi 2.6.15
 
 * Add PEPFAR Datim UID for Burundi.

--- a/R/tmb-model-r-implementation.R
+++ b/R/tmb-model-r-implementation.R
@@ -271,16 +271,17 @@ naomi_objective_function_r <- function(d, p) {
   rho_15to49_t1 <- plhiv_15to49_t1 / as.vector(d$X_15to49 %*% d$population_t1)
   alpha_15to49_t1 <- (d$X_15to49 %*% artnum_t1) / plhiv_15to49_t1
 
-  mu_lambda_t1 <- d$X_lambda %*% p$beta_lambda + d$log_lambda_t1_offset +
+  mu_lambda_t1 <- d$X_lambda %*% p$beta_lambda +
+    d$log_lambda_t1_offset +
     d$Z_x %*% (log(rho_15to49_t1) + log(1.0 - d$omega * alpha_15to49_t1)) +
     d$Z_lambda_x %*% p$ui_lambda_x
   mu_lambda_t1 <- as.vector(mu_lambda_t1)
 
-  lambda_t1 <- exp(mu_lambda_t1)
+  lambda_adult_t1 <- exp(mu_lambda_t1)
 
   ## Add paediatric incidence
   lambda_paed_t1 <- as.vector(d$X_paed_lambda_ratio_t1 %*% rho_15to49f_t1)
-  lambda_t1 <- lambda_t1 + lambda_paed_t1
+  lambda_t1 <- lambda_adult_t1 + lambda_paed_t1
 
   infections_t1 <- lambda_t1 * (d$population_t1 - plhiv_t1)
 
@@ -295,9 +296,9 @@ naomi_objective_function_r <- function(d, p) {
 
   alpha_t2 <- plogis(mu_alpha_t2)
 
-  infections_t1t2 <- (1 - exp(-lambda_t1 * d$projection_duration_t1t2)) * (d$population_t1 - plhiv_t1)
+  infections_adult_t1t2 <- (1 - exp(-lambda_adult_t1 * d$projection_duration_t1t2)) * (d$population_t1 - plhiv_t1)
   plhiv_t2 <- d$Lproj_hivpop_t1t2 %*% plhiv_t1 +
-    d$Lproj_incid_t1t2  %*% infections_t1t2 +
+    d$Lproj_incid_t1t2  %*% infections_adult_t1t2 +
     d$Lproj_paed_t1t2  %*% plhiv_t1
   plhiv_t2 <- as.vector(plhiv_t2)
 
@@ -315,12 +316,12 @@ naomi_objective_function_r <- function(d, p) {
     d$Z_lambda_x %*% p$ui_lambda_x
   mu_lambda_t2 <- as.vector(mu_lambda_t2)
 
-  lambda_t2 <- exp(mu_lambda_t2)
+  lambda_adult_t2 <- exp(mu_lambda_t2)
 
   ## Add paediatric incidence
   rho_15to49f_t2 <- d$X_15to49f %*% (plogis(mu_rho) * d$population_t2) / (d$X_15to49f %*% d$population_t2)  
   lambda_paed_t2 <- as.vector(d$X_paed_lambda_ratio_t2 %*% rho_15to49f_t2)
-  lambda_t2 <- lambda_t2 + lambda_paed_t2
+  lambda_t2 <- lambda_adult_t2 + lambda_paed_t2
 
   infections_t2 <- lambda_t2 * (d$population_t2 - plhiv_t2)
 
@@ -568,9 +569,9 @@ naomi_objective_function_r <- function(d, p) {
   mu_alpha_t3 <- mu_alpha_t2 + d$logit_alpha_t2t3_offset
   alpha_t3 <- plogis(mu_alpha_t3)
 
-  infections_t2t3 <- (1 - exp(-lambda_t2 * d$projection_duration_t2t3)) * (d$population_t2 - plhiv_t2)
+  infections_adult_t2t3 <- (1 - exp(-lambda_adult_t2 * d$projection_duration_t2t3)) * (d$population_t2 - plhiv_t2)
   plhiv_t3 <- as.vector(d$Lproj_hivpop_t2t3 %*% plhiv_t2 +
-                        d$Lproj_incid_t2t3 %*% infections_t2t3 +
+                        d$Lproj_incid_t2t3 %*% infections_adult_t2t3 +
                         d$Lproj_paed_t2t3 %*% plhiv_t2)
 
   rho_t3 <- plhiv_t3 / d$population_t3
@@ -586,12 +587,12 @@ naomi_objective_function_r <- function(d, p) {
     d$Z_x %*% (log(rho_15to49_t3) + log(1.0 - d$omega * alpha_15to49_t3)) +
     d$Z_lambda_x %*% p$ui_lambda_x
 
-  lambda_t3 <- exp(mu_lambda_t3)
+  lambda_adult_t3 <- exp(mu_lambda_t3)
 
   ## Add paediatric incidence
   rho_15to49f_t3 <- d$X_15to49f %*% (plogis(mu_rho) * d$population_t3) / (d$X_15to49f %*% d$population_t3)  
   lambda_paed_t3 <- as.vector(d$X_paed_lambda_ratio_t3 %*% rho_15to49f_t3)
-  lambda_t3 <- lambda_t3 + lambda_paed_t3
+  lambda_t3 <- lambda_adult_t3 + lambda_paed_t3
 
   
   infections_t3 <- lambda_t3 * (d$population_t3 - plhiv_t3)

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -523,11 +523,11 @@ Type objective_function<Type>::operator() ()
                             Z_x * vector<Type>(log(rho_15to49_t1) + log(1.0 - omega * alpha_15to49_t1)) +
                             Z_lambda_x * ui_lambda_x);
 
-  vector<Type> lambda_t1(exp(mu_lambda_t1));
+  vector<Type> lambda_adult_t1(exp(mu_lambda_t1));
 
   // Add paediatric incidence
   vector<Type> lambda_paed_t1(X_paed_lambda_ratio_t1 * rho_15to49f_t1);
-  lambda_t1 += lambda_paed_t1;
+  vector<Type> lambda_t1(lambda_adult_t1 + lambda_paed_t1);
   
   vector<Type> infections_t1(lambda_t1 * (population_t1 - plhiv_t1));
 
@@ -541,8 +541,8 @@ Type objective_function<Type>::operator() ()
 			   Z_alpha_xst * u_alpha_xst);
   vector<Type> alpha_t2(invlogit(mu_alpha_t2));
 
-  vector<Type> infections_t1t2((1 - exp(-lambda_t1 * projection_duration_t1t2)) * (population_t1 - plhiv_t1));
-  vector<Type> plhiv_t2(Lproj_hivpop_t1t2 * plhiv_t1 + Lproj_incid_t1t2 * infections_t1t2 + Lproj_paed_t1t2 * plhiv_t1);
+  vector<Type> infections_adult_t1t2((1 - exp(-lambda_adult_t1 * projection_duration_t1t2)) * (population_t1 - plhiv_t1));
+  vector<Type> plhiv_t2(Lproj_hivpop_t1t2 * plhiv_t1 + Lproj_incid_t1t2 * infections_adult_t1t2 + Lproj_paed_t1t2 * plhiv_t1);
 
   vector<Type> rho_t2(plhiv_t2 / population_t2);
   vector<Type> prop_art_t2(rho_t2 * alpha_t2);
@@ -557,12 +557,12 @@ Type objective_function<Type>::operator() ()
                             Z_x * vector<Type>(log(rho_15to49_t2) + log(1.0 - omega * alpha_15to49_t2)) +
                             Z_lambda_x * ui_lambda_x);
 
-  vector<Type> lambda_t2(exp(mu_lambda_t2));
+  vector<Type> lambda_adult_t2(exp(mu_lambda_t2));
 
   // Add paediatric incidence
   vector<Type> rho_15to49f_t2((X_15to49f * vector<Type>(invlogit(mu_rho) * population_t2)) / (X_15to49f * population_t2));  
   vector<Type> lambda_paed_t2(X_paed_lambda_ratio_t2 * rho_15to49f_t2);
-  lambda_t2 += lambda_paed_t2;
+  vector<Type> lambda_t2(lambda_adult_t2 + lambda_paed_t2);
   
   vector<Type> infections_t2(lambda_t2 * (population_t2 - plhiv_t2));
 
@@ -831,8 +831,8 @@ Type objective_function<Type>::operator() ()
     vector<Type> mu_alpha_t3(mu_alpha_t2 + logit_alpha_t2t3_offset);
     vector<Type> alpha_t3(invlogit(mu_alpha_t3));
     
-    vector<Type> infections_t2t3((1 - exp(-lambda_t2 * projection_duration_t2t3)) * (population_t2 - plhiv_t2));
-    vector<Type> plhiv_t3(Lproj_hivpop_t2t3 * plhiv_t2 + Lproj_incid_t2t3 * infections_t2t3 + Lproj_paed_t2t3 * plhiv_t2);
+    vector<Type> infections_adult_t2t3((1 - exp(-lambda_adult_t2 * projection_duration_t2t3)) * (population_t2 - plhiv_t2));
+    vector<Type> plhiv_t3(Lproj_hivpop_t2t3 * plhiv_t2 + Lproj_incid_t2t3 * infections_adult_t2t3 + Lproj_paed_t2t3 * plhiv_t2);
     
     vector<Type> rho_t3(plhiv_t3 / population_t3);
     vector<Type> prop_art_t3(rho_t3 * alpha_t3);
@@ -846,12 +846,12 @@ Type objective_function<Type>::operator() ()
 			      Z_x * vector<Type>(log(rho_15to49_t3) + log(1.0 - omega * alpha_15to49_t3)) +
 			      Z_lambda_x * ui_lambda_x);
 
-    vector<Type> lambda_t3(exp(mu_lambda_t3));
+    vector<Type> lambda_adult_t3(exp(mu_lambda_t3));
     
     // Add paediatric incidence
     vector<Type> rho_15to49f_t3((X_15to49f * vector<Type>(invlogit(mu_rho) * population_t3)) / (X_15to49f * population_t3));  
     vector<Type> lambda_paed_t3(X_paed_lambda_ratio_t3 * rho_15to49f_t3);
-    lambda_t3 += lambda_paed_t3;
+    vector<Type> lambda_t3(lambda_adult_t3 + lambda_paed_t3);
 
     vector<Type> infections_t3(lambda_t3 * (population_t3 - plhiv_t3));
 


### PR DESCRIPTION
Bug fix: this PR removes child new infections from the T1 -> T2 projection because these infections are accounted for separately already in the paediatric projection matrix. 

This addresses an issue introduced in v2.6.0 when paediatric new infections were added to the Naomi output.

It will most severely affect child PLHIV outputs for settings where the survey was long time ago; modest effect in cases where survey was 1-2 years ago.