### PR TITLE
Ignore any non PJNZ files when using zip of PJNZ

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -92,3 +92,7 @@ match_values <- function(args, choices, name = deparse(substitute(args))) {
   }
   args
 }
+
+vlapply <- function(X, FUN, ...) {
+  vapply(X, FUN, ..., FUN.VALUE = logical(1))
+}


### PR DESCRIPTION
We fixed this in hintr but overlooked fixing it here https://github.com/mrc-ide/hintr/pull/353/files I've ported that code over to here.

This means that when mac users upload a zip file created on their machine it will ignore the __MACOSX folder that macs helpfully add