### PR TITLE
Add arg to hintr_prepare_spectrum_download for arbitrary notes to be added into zip

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.25
+Version: 2.6.26
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.26
+
+* `hintr_prepare_spectrum_download` now takes arg `notes` for arbitrary notes which will be added into the output zip
+
 # naomi 2.6.25
 
 * Fix anc aggregation

--- a/R/downloads.R
+++ b/R/downloads.R
@@ -2,18 +2,20 @@
 #'
 #' @param output hintr output object
 #' @param path Path to save output file
+#' @param notes User added notes from front end of app as a string
 #'
 #' @return Path to output file and metadata for file
 #' @export
 hintr_prepare_spectrum_download <- function(output,
-                                            path = tempfile(fileext = ".zip")) {
+                                            path = tempfile(fileext = ".zip"),
+                                            notes = NULL) {
   assert_model_output_version(output)
   progress <- new_simple_progress()
   progress$update_progress("PROGRESS_DOWNLOAD_SPECTRUM")
   model_output <- readRDS(output$model_output_path)
   options <- yaml::read_yaml(text = model_output$info$options.yml)
   list(
-    path = save_output_spectrum(path, model_output$output_package),
+    path = save_output_spectrum(path, model_output$output_package, notes),
     metadata = list(
       description = build_output_description(options),
       areas = options$area_scope,

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -337,7 +337,7 @@ output_package <- function(naomi_fit, naomi_data, na.rm = FALSE) {
 
   meta_indicator <- get_meta_indicator()
   meta_indicator <- dplyr::filter(meta_indicator, indicator %in% indicators$indicator)
-                                     
+
   val <- list(
     indicators = indicators,
     art_attendance = art_attendance,
@@ -662,6 +662,7 @@ subset_naomi_output <- function(naomi_output,
 #' @param naomi_output Naomi output object
 #' @param filename Name of file to create
 #' @param dir Directory to create zip in
+#' @param notes Notes to include in output zip
 #' @param overwrite If TRUE overwrite any existing file
 #' @param with_labels If TRUE save indicator ids with labels
 #' @param boundary_format Either geojson or shp for saving boundary as geojson
@@ -675,14 +676,20 @@ subset_naomi_output <- function(naomi_output,
 save_output_package <- function(naomi_output,
                                 filename,
                                 dir,
+                                notes = NULL,
                                 overwrite = FALSE,
                                 with_labels = FALSE,
                                 boundary_format = "geojson",
                                 single_csv = FALSE,
                                 export_datapack = !single_csv) {
 
-  save_output(filename, dir, naomi_output, overwrite,
-              with_labels, boundary_format, single_csv, export_datapack)
+  save_output(filename, dir, naomi_output,
+              notes = notes,
+              overwrite = overwrite,
+              with_labels = with_labels,
+              boundary_format = boundary_format,
+              single_csv = single_csv,
+              export_datapack = export_datapack)
 }
 
 save_output_coarse_age_groups <- function(path, naomi_output,
@@ -698,8 +705,9 @@ save_output_coarse_age_groups <- function(path, naomi_output,
               export_datapack = FALSE)
 }
 
-save_output_spectrum <- function(path, naomi_output, overwrite = FALSE) {
-  save_output(basename(path), dirname(path), naomi_output,
+save_output_spectrum <- function(path, naomi_output, notes = NULL,
+                                 overwrite = FALSE) {
+  save_output(basename(path), dirname(path), naomi_output, notes,
               overwrite = overwrite, with_labels = TRUE,
               boundary_format = "geojson", single_csv = FALSE,
               export_datapack = TRUE)
@@ -711,6 +719,7 @@ save_output_spectrum <- function(path, naomi_output, overwrite = FALSE) {
 #' @param options Naomi model options
 #' @param filename Name of file to create
 #' @param dir Directory to create zip in
+#' @param notes Notes to include in output zip
 #' @param overwrite If TRUE overwrite any existing file
 #' @param with_labels If TRUE save indicator ids with labels
 #' @param boundary_format Either geojson or shp for saving boundary as geojson
@@ -723,6 +732,7 @@ save_output_spectrum <- function(path, naomi_output, overwrite = FALSE) {
 #' @export
 save_output <- function(filename, dir,
                         naomi_output,
+                        notes = NULL,
                         overwrite = FALSE,
                         with_labels = FALSE,
                         boundary_format = "geojson",
@@ -742,7 +752,6 @@ save_output <- function(filename, dir,
     stop(paste(
       "File", path, "already exists. Set overwrite = TRUE to write output."))
   }
-
   naomi_output$indicators <- remove_output_labels(naomi_output)
   naomi_output$art_attendance <- remove_art_attendance_labels(naomi_output)
 
@@ -759,6 +768,11 @@ save_output <- function(filename, dir,
   old <- setwd(tmpd)
   on.exit(setwd(old))
   naomi_write_csv(indicators, "indicators.csv")
+
+  if (!is.null(notes)) {
+    assert_scalar_character(notes)
+    writeLines(notes, "notes.txt")
+  }
 
   if(!single_csv) {
     naomi_write_csv(art_attendance, "art_attendance.csv")
@@ -808,6 +822,10 @@ save_output <- function(filename, dir,
     yaml::write_yaml(fit$model_options, "fit/model_options.yml")
     yaml::write_yaml(fit$data_options, "fit/data_options.yml")
     yaml::write_yaml(fit$calibration_options, "fit/calibration_options.yml")
+  }
+
+  if (!is.null(notes)) {
+
   }
 
   zip::zipr(path, list.files())

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -2,9 +2,11 @@ context("downloads")
 
 test_that("spectrum download can be created", {
   mock_new_simple_progress <- mockery::mock(MockSimpleProgress$new())
+  notes <- "these are my\nmultiline notes"
   with_mock("naomi:::new_simple_progress" = mock_new_simple_progress, {
     messages <- naomi_evaluate_promise(
-      out <- hintr_prepare_spectrum_download(a_hintr_output_calibrated))
+      out <- hintr_prepare_spectrum_download(a_hintr_output_calibrated,
+                                             notes = notes))
   })
   expect_true(file.exists(out$path))
 
@@ -62,6 +64,12 @@ test_that("spectrum download can be created", {
   expect_length(messages$progress, 1)
   expect_equal(messages$progress[[1]]$message,
                "Generating output zip download")
+
+  ## Notes are saved
+  t <- tempfile()
+  unzip(out$path, "notes.txt", exdir = t)
+  saved_notes <- readLines(file.path(t, "notes.txt"))
+  expect_equal(saved_notes, c("these are my", "multiline notes"))
 })
 
 test_that("coarse age group download can be created", {


### PR DESCRIPTION
hintr will pass in notes from the front end for this, couple of questions for you both
* I've exposed the notes in `save_output_package` too - is that useful?
* If a user writes no notes there won't be a file generated, would you prefer to add an empty file? or keep no file
* Is it useful to pull the notes out in `read_output_package`? This PR is not doing that at the moment