### PR TITLE
Trigger warning when anc and art input numbers do not agree with spectrum numbers

### DIFF
--- a/R/run-model.R
+++ b/R/run-model.R
@@ -418,11 +418,13 @@ naomi_prepare_data <- function(data, options) {
 
   if (!is.null(data$art_number)) {
     art_number <- read_art_number(data$art_number$path)
+    art_spectrum_warning(art_number, area_merged, spec_program_data)
   } else {
     art_number <- NULL
   }
   if (!is.null(data$anc_testing)) {
     anc_testing <- read_anc_testing(data$anc_testing$path)
+    anc_spectrum_warning(anc_testing, area_merged, spec_program_data)
   } else {
     anc_testing <- NULL
   }

--- a/R/warnings.R
+++ b/R/warnings.R
@@ -102,14 +102,16 @@ art_spectrum_warning <- function(art, shape, pjnz) {
 
   ## Check if art is object or file path
   if(!inherits(art, c("spec_tbl_df","tbl_df","tbl","data.frame" ))) {
-    art_number <- read_art_number(art, all_columns = TRUE)
+    art <- read_art_number(art, all_columns = TRUE)
   }
 
-  ## Read in spectrum programme data
-  spec_program_data <- extract_pjnz_program_data(pjnz)
+  ## PJNZ either object or file path
+  if (!inherits(pjnz, "spec_program_data")) {
+    pjnz <- extract_pjnz_program_data(pjnz)
+  }
 
   ## Check if art totals match spectrum totals
-  art_merged <- art_number %>%
+  art_merged <- art %>%
       dplyr::left_join(
         dplyr::select(areas, area_id, area_name, spectrum_region_code),
         by = "area_id"
@@ -117,7 +119,7 @@ art_spectrum_warning <- function(art, shape, pjnz) {
       dplyr::count(spectrum_region_code, sex, age_group, area_name, calendar_quarter,
                    wt = art_current, name = "value_naomi") %>%
       dplyr::inner_join(
-        spec_program_data$art_dec31 %>%
+        pjnz$art_dec31 %>%
           dplyr::mutate(
             calendar_quarter = paste0("CY", year, "Q4")
           ),
@@ -163,14 +165,16 @@ anc_spectrum_warning <- function(anc, shape, pjnz) {
 
   ## Check if anc is object or file path
   if(!inherits(anc, c("spec_tbl_df","tbl_df","tbl","data.frame" ))) {
-    anc_testing <- read_anc_testing(anc)
+    anc <- read_anc_testing(anc)
   }
 
-  ## Read in spectrum programme data
-  spec_program_data <- extract_pjnz_program_data(pjnz)
+  ## PJNZ either object or file path
+  if (!inherits(pjnz, "spec_program_data")) {
+    pjnz <- extract_pjnz_program_data(pjnz)
+  }
 
   ## Check if art totals match spectrum totals
-  anc_merged <- anc_testing %>%
+  anc_merged <- anc %>%
     dplyr::left_join(
       dplyr::select(areas, area_id,area_name, spectrum_region_code),
       by = "area_id"
@@ -181,7 +185,7 @@ anc_spectrum_warning <- function(anc, shape, pjnz) {
     dplyr::count(spectrum_region_code, age_group, area_name, year, indicator,
                  wt = value_naomi, name = "value_naomi") %>%
     dplyr::inner_join(
-      spec_program_data$anc_testing %>%
+      pjnz$anc_testing %>%
         dplyr::rename("value_spectrum" = "value"),
       by = c("spectrum_region_code", "indicator", "year")
     ) %>%

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -212,7 +212,8 @@ test_that("calibration options used in summary report if present", {
   t <- tempfile(fileext = ".html")
   generate_output_summary_report(t, zip$path, quiet = TRUE)
   content <- brio::readLines(t)
-  expect_true(any(grepl("Sex and 5-year age group", content)))
+  expect_true(any(grepl("Sex and 5-year age group",
+                        paste0(content, collapse = " "))))
 })
 
 test_that("output_package() catches error if NA in simulated sample.", {

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -21,7 +21,12 @@ test_that("model can be run", {
                c("inputs.csv", "options.yml", "packages.csv"))
   expect_equal(output$warnings$model_fit, model_run$warnings)
 
-  expect_equal(model_run$warnings, list())
+  expect_length(model_run$warnings, 3)
+  msgs <- lapply(model_run$warnings, function(x) x$text)
+  expect_true(any(grepl("Naomi ART current not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC testing not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC tested positive not equal to Spectrum",
+                        msgs)))
 })
 
 test_that("model can be run without programme data", {
@@ -200,11 +205,17 @@ test_that("exceeding max_iterations raises convergence warning", {
 
   output_path <- tempfile()
   out <- hintr_run_model(data, options, output_path)
-  expect_length(out$warnings, 2)
+  expect_length(out$warnings, 5)
   expect_equal(out$warnings[[1]]$text,
                paste0("You have chosen to fit model without estimating ",
                "neighbouring ART attendance. You may wish to review your ",
                "selection to include this option."))
+
+  msgs <- lapply(out$warnings, function(x) x$text)
+  expect_true(any(grepl("Naomi ART current not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC testing not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC tested positive not equal to Spectrum",
+                        msgs)))
 })
 
 test_that("invalid time sequencing returns an error", {

--- a/tests/testthat/test-warning.R
+++ b/tests/testthat/test-warning.R
@@ -61,8 +61,14 @@ test_that("warning raised after false convergence", {
       out <- hintr_run_model(a_hintr_data, a_hintr_options, validate = FALSE)
     })
 
-  expect_length(out$warnings, 1)
-  expect_equal(out$warnings[[1]]$text,
+  expect_length(out$warnings, 4)
+  expect_match(out$warnings[[1]]$text,
+               "Naomi ART current not equal to Spectrum")
+  expect_match(out$warnings[[2]]$text,
+               "Naomi ANC testing not equal to Spectrum")
+  expect_match(out$warnings[[3]]$text,
+               "Naomi ANC tested positive not equal to Spectrum")
+  expect_equal(out$warnings[[4]]$text,
                "Convergence error: false convergence (8)")
 })
 
@@ -97,12 +103,17 @@ test_that("warning raised if outputs exceed threshold", {
       out <- hintr_run_model(a_hintr_data, a_hintr_options, validate = FALSE)
     })
 
-  expect_length(out$warnings, 2)
+  expect_length(out$warnings, 5)
+  msgs <- lapply(out$warnings, function(x) x$text)
+  expect_true(any(grepl("Naomi ART current not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC testing not equal to Spectrum", msgs)))
+  expect_true(any(grepl("Naomi ANC tested positive not equal to Spectrum",
+                        msgs)))
   expect_equal(
-    out$warnings[[1]]$text,
+    out$warnings[[4]]$text,
     "HIV prevalence is higher than 50% for: March 2016, Northern, Both, 0-4")
   expect_equal(
-    out$warnings[[2]]$text,
+    out$warnings[[5]]$text,
     "ART coverage is higher than 100% for: March 2016, Northern, Both, 0-4")
 })
 


### PR DESCRIPTION
As agreed with Ian, we're just going to trigger these warnings during the model fit now and in the future either we can look at adding tables to show users or leave this to be a warning that gets shown in the ADR