### PR TITLE
Qualify package name in remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,5 +65,5 @@ LinkingTo:
 Remotes:
     bergant/datamodelr,
     mrc-ide/eppasm,
-    mrc-ide/first90release,
+    first90=mrc-ide/first90release,
     reside-ic/traduire


### PR DESCRIPTION
This fixes the installation with pak/pkgdepends. Cf. https://github.com/r-lib/pkgdepends/issues/282