### PR TITLE
Move ANC and ART spectrum data mismatch warnings to be shown on model calibrate page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.26
+Version: 2.6.27
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.27
+
+* Move ANC and ART spectrum data mismatch warnings to be shown on model calibrate page
+
 # naomi 2.6.26
 
 * `hintr_prepare_spectrum_download` now takes arg `notes` for arbitrary notes which will be added into the output zip

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.6.27
 
-* Move ANC and ART spectrum data mismatch warnings to be shown on model calibrate page
+* Move ANC and ART spectrum data mismatch warnings to be shown on model calibrate and review result pages
 
 # naomi 2.6.26
 

--- a/R/warnings.R
+++ b/R/warnings.R
@@ -127,10 +127,11 @@ art_spectrum_warning <- function(art, shape, pjnz) {
       ) %>%
     dplyr::rename(value_spectrum = art_dec31)
 
-  format_spectrum_total_warning(data_merged = art_merged,
-                                key = "WARNING_ART_NOT_EQUAL_TO_SPECTRUM",
-                                location = "review_inputs",
-                                age_disag = TRUE)
+  format_spectrum_total_warning(
+    data_merged = art_merged,
+    key = "WARNING_ART_NOT_EQUAL_TO_SPECTRUM",
+    location = "model_calibrate",
+    age_disag = TRUE)
 
 }
 
@@ -196,14 +197,15 @@ anc_spectrum_warning <- function(anc, shape, pjnz) {
   anc_tested_pos <- anc_merged[anc_merged$indicator == "anc_tested_pos",]
 
   # Generate warning if totals are not aligned
-  format_spectrum_total_warning(data_merged = anc_tested,
-                                key = "WARNING_ANC_TEST_NOT_EQUAL_TO_SPECTRUM",
-                                location = "review_inputs")
+  format_spectrum_total_warning(
+    data_merged = anc_tested,
+    key = "WARNING_ANC_TEST_NOT_EQUAL_TO_SPECTRUM",
+    location = "model_calibrate")
 
   format_spectrum_total_warning(
     data_merged = anc_tested_pos,
     key = "WARNING_ANC_TEST_POS_NOT_EQUAL_TO_SPECTRUM",
-    location = "review_inputs")
+    location = "model_calibrate")
 }
 
 ##' Format spectrum total warnings

--- a/R/warnings.R
+++ b/R/warnings.R
@@ -130,7 +130,7 @@ art_spectrum_warning <- function(art, shape, pjnz) {
   format_spectrum_total_warning(
     data_merged = art_merged,
     key = "WARNING_ART_NOT_EQUAL_TO_SPECTRUM",
-    location = "model_calibrate",
+    location = c("model_calibrate", "review_output"),
     age_disag = TRUE)
 
 }
@@ -200,12 +200,12 @@ anc_spectrum_warning <- function(anc, shape, pjnz) {
   format_spectrum_total_warning(
     data_merged = anc_tested,
     key = "WARNING_ANC_TEST_NOT_EQUAL_TO_SPECTRUM",
-    location = "model_calibrate")
+    location = c("model_calibrate", "review_output"))
 
   format_spectrum_total_warning(
     data_merged = anc_tested_pos,
     key = "WARNING_ANC_TEST_POS_NOT_EQUAL_TO_SPECTRUM",
-    location = "model_calibrate")
+    location = c("model_calibrate", "review_output"))
 }
 
 ##' Format spectrum total warnings

--- a/tests/testthat/test-warning.R
+++ b/tests/testthat/test-warning.R
@@ -123,7 +123,7 @@ test_that("ART warning raised if spectrum totals do not match naomi data", {
                               a_hintr_data$pjnz)
 
   expect_length(art_w$warnings, 1)
-  expect_equal(art_w$warnings[[1]]$locations, "review_inputs")
+  expect_equal(art_w$warnings[[1]]$locations, "model_calibrate")
   expect_true(grepl("Naomi ART current not equal to Spectrum",
                     art_w$warnings[[1]]$text))
   expect_true(grepl("2018 Y000_014 Northern",
@@ -144,7 +144,7 @@ test_that("ANC warning raised if spectrum totals do not match naomi data", {
 
   expect_length(anc_w$warnings, 2)
 
-  expect_equal(anc_w$warnings[[1]]$locations, "review_inputs")
+  expect_equal(anc_w$warnings[[1]]$locations, "model_calibrate")
   expect_true(grepl("Naomi ANC testing not equal to Spectrum",
                     anc_w$warnings[[1]]$text))
   expect_true(grepl("2018 Northern",
@@ -156,7 +156,7 @@ test_that("ANC warning raised if spectrum totals do not match naomi data", {
   expect_true(grepl("and \\d+ more",
                     anc_w$warnings[[1]]$text))
 
-  expect_equal(anc_w$warnings[[2]]$locations, "review_inputs")
+  expect_equal(anc_w$warnings[[2]]$locations, "model_calibrate")
   expect_true(grepl("Naomi ANC tested positive not equal to Spectrum",
                     anc_w$warnings[[2]]$text))
   expect_true(grepl("2018 Northern",

--- a/tests/testthat/test-warning.R
+++ b/tests/testthat/test-warning.R
@@ -123,7 +123,8 @@ test_that("ART warning raised if spectrum totals do not match naomi data", {
                               a_hintr_data$pjnz)
 
   expect_length(art_w$warnings, 1)
-  expect_equal(art_w$warnings[[1]]$locations, "model_calibrate")
+  expect_equal(art_w$warnings[[1]]$locations,
+               c("model_calibrate", "review_output"))
   expect_true(grepl("Naomi ART current not equal to Spectrum",
                     art_w$warnings[[1]]$text))
   expect_true(grepl("2018 Y000_014 Northern",
@@ -144,7 +145,8 @@ test_that("ANC warning raised if spectrum totals do not match naomi data", {
 
   expect_length(anc_w$warnings, 2)
 
-  expect_equal(anc_w$warnings[[1]]$locations, "model_calibrate")
+  expect_equal(anc_w$warnings[[1]]$locations,
+               c("model_calibrate", "review_output"))
   expect_true(grepl("Naomi ANC testing not equal to Spectrum",
                     anc_w$warnings[[1]]$text))
   expect_true(grepl("2018 Northern",
@@ -156,7 +158,8 @@ test_that("ANC warning raised if spectrum totals do not match naomi data", {
   expect_true(grepl("and \\d+ more",
                     anc_w$warnings[[1]]$text))
 
-  expect_equal(anc_w$warnings[[2]]$locations, "model_calibrate")
+  expect_equal(anc_w$warnings[[2]]$locations,
+               c("model_calibrate", "review_output"))
   expect_true(grepl("Naomi ANC tested positive not equal to Spectrum",
                     anc_w$warnings[[2]]$text))
   expect_true(grepl("2018 Northern",


### PR DESCRIPTION
At the moment these warnings are generated during the model fit but shown on input review stage, so many users will miss them unless they go back to previous steps. They need be shown on model fit stage or later so that users actually see them during normal flow through the app. This PR moves them to be shown on the model calibrate step, but we can show anywhere you guys think is appropriate.