### PR TITLE
patch eppasm::simmod() input for eppasm_v0.6.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.6.27
+Version: 2.6.28
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.6.28
+
+* Patch for incidence input argument in EPP-ASM simulation for `eppasm_v0.6.2`.
+
 # naomi 2.6.27
 
 * Move ANC and ART spectrum data mismatch warnings to be shown on model calibrate and review result pages

--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -56,7 +56,7 @@ extract_pjnz_one <- function(pjnz) {
   specres <- eppasm::read_hivproj_output(pjnz)
 
   specfp <- eppasm:::create_spectrum_fixpar(projp, demp)
-  specfp$eppmod <- "directincid"
+  specfp$eppmod <- "directincid_hts"
   specfp$incidinput <- eppasm::incid(specres)
   specfp$incidpopage <- 0L  ## age 15-49
 


### PR DESCRIPTION
This patches input to `eppasm::specfp()` for eppasm_v0.6.2.

Addresses this error:
```
Quitting from lines 28-81 (hintr-example.Rmd)  
Error: processing vignette 'hintr-example.Rmd' failed with diagnostics:
tsEpidemicStart missing from list
```