### PR TITLE
Add default value for births_facility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.7.0
+Version: 2.7.1
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.7.1
 
-* If `births_facility` in ANC data is missing or `NA` it will be replaced by `0` when reading input
+* If `births_facility` in ANC data is missing it will be replaced by `NA` when reading input so input time series aggregation passes
 
 # naomi 2.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.7.1
+
+* If `births_facility` in ANC data is missing or `NA` it will be replaced by `0` when reading input
+
 # naomi 2.7.0
 
 Updates for 2023 UNAIDS estimates (Dec 2022 - Mar 2023).

--- a/R/read-data.R
+++ b/R/read-data.R
@@ -178,8 +178,7 @@ read_anc_testing <- function(file) {
     val[["anc_known_neg"]] <- 0
   }
 
-  if ( !("births_facility" %in% names(val)) ||
-       all(is.na(val[["births_facility"]])) ) {
+  if ( !("births_facility" %in% names(val)) ) {
     val[["births_facility"]] <- NA_real_
   }
 

--- a/R/read-data.R
+++ b/R/read-data.R
@@ -180,7 +180,7 @@ read_anc_testing <- function(file) {
 
   if ( !("births_facility" %in% names(val)) ||
        all(is.na(val[["births_facility"]])) ) {
-    val[["births_facility"]] <- 0
+    val[["births_facility"]] <- NA_real_
   }
 
   ## !! TODO: add validation asserts -- probably pull in hintr validation_asserts.R

--- a/R/read-data.R
+++ b/R/read-data.R
@@ -178,6 +178,11 @@ read_anc_testing <- function(file) {
     val[["anc_known_neg"]] <- 0
   }
 
+  if ( !("births_facility" %in% names(val)) ||
+       all(is.na(val[["births_facility"]])) ) {
+    val[["births_facility"]] <- 0
+  }
+
   ## !! TODO: add validation asserts -- probably pull in hintr validation_asserts.R
 
   val

--- a/tests/testthat/test-input-time-series.R
+++ b/tests/testthat/test-input-time-series.R
@@ -296,3 +296,23 @@ test_that("anc input time series can handle data with NA rows", {
   ## Check that NA entry has been removed
   expect_true(!any(is.na(unique(data$age_group))))
 })
+
+
+test_that("ANC data without births_facility can be aggregated", {
+  anc <- read_anc_testing(a_hintr_data$anc_testing)
+  anc$births_facility <- NULL
+  t <- tempfile(fileext = ".csv")
+  readr::write_csv(anc, t, na = "")
+
+  data <- aggregate_anc(t, a_hintr_data$shape)
+
+  expect_true(nrow(data) > 50) ## Check that we have read out some data
+  expect_setequal(colnames(data),
+                  c("area_id", "area_name", "area_level","area_level_label",
+                    "parent_area_id", "area_sort_order", "sex", "age_group",
+                    "time_period", "year", "quarter", "calendar_quarter",
+                    "anc_clients", "anc_known_pos" , "anc_already_art", "anc_tested",
+                    "anc_tested_pos","anc_known_neg","births_facility", "area_hierarchy"))
+
+  expect_equal(data$births_facility, rep(0, nrow(data)))
+})

--- a/tests/testthat/test-input-time-series.R
+++ b/tests/testthat/test-input-time-series.R
@@ -296,4 +296,3 @@ test_that("anc input time series can handle data with NA rows", {
   ## Check that NA entry has been removed
   expect_true(!any(is.na(unique(data$age_group))))
 })
-

--- a/tests/testthat/test-read-data.R
+++ b/tests/testthat/test-read-data.R
@@ -90,7 +90,7 @@ test_that("reading utils can handle files with , in numeric columns", {
   expect_equal(art_fr$art_current[2], 2031)
 })
 
-test_that("read_anc_testing() handles data set without 'anc_known_neg' column", {
+test_that("read_anc_testing() handles data set without 'anc_known_neg' or 'births_facility' columns", {
 
   raw <- read_anc_testing(system_file("extdata/demo_anc_testing.csv"))
 
@@ -106,11 +106,11 @@ test_that("read_anc_testing() handles data set without 'anc_known_neg' column", 
   anc_missing_known_neg <- read_anc_testing(f1)
 
   expect_equal(anc_missing_known_neg$anc_known_neg, rep(0.0, nrow(raw)))
-  expect_null(anc_missing_known_neg[["births_facility"]])
+  expect_equal(anc_missing_known_neg[["births_facility"]], rep(0.0, nrow(raw)))
 
   expect_equal(calculate_anc_prevalence(raw),
                calculate_anc_prevalence(anc_missing_known_neg))
-              
+
   ## Column anc_known_neg exists, but all values NA
   new2 <- raw
   new2$anc_tested <- raw$anc_tested + raw$anc_known_neg
@@ -123,7 +123,7 @@ test_that("read_anc_testing() handles data set without 'anc_known_neg' column", 
   anc_na_known_neg <- read_anc_testing(f2)
 
   expect_equal(anc_na_known_neg$anc_known_neg, rep(0.0, nrow(raw)))
-  expect_null(anc_na_known_neg[["births_facility"]])
+  expect_equal(anc_na_known_neg[["births_facility"]], rep(0.0, nrow(raw)))
 
   expect_equal(calculate_anc_prevalence(raw),
                calculate_anc_prevalence(anc_na_known_neg))

--- a/tests/testthat/test-read-data.R
+++ b/tests/testthat/test-read-data.R
@@ -106,7 +106,8 @@ test_that("read_anc_testing() handles data set without 'anc_known_neg' or 'birth
   anc_missing_known_neg <- read_anc_testing(f1)
 
   expect_equal(anc_missing_known_neg$anc_known_neg, rep(0.0, nrow(raw)))
-  expect_equal(anc_missing_known_neg[["births_facility"]], rep(0.0, nrow(raw)))
+  expect_equal(anc_missing_known_neg[["births_facility"]],
+               rep(NA_real_, nrow(raw)))
 
   expect_equal(calculate_anc_prevalence(raw),
                calculate_anc_prevalence(anc_missing_known_neg))
@@ -123,7 +124,7 @@ test_that("read_anc_testing() handles data set without 'anc_known_neg' or 'birth
   anc_na_known_neg <- read_anc_testing(f2)
 
   expect_equal(anc_na_known_neg$anc_known_neg, rep(0.0, nrow(raw)))
-  expect_equal(anc_na_known_neg[["births_facility"]], rep(0.0, nrow(raw)))
+  expect_equal(anc_na_known_neg[["births_facility"]], rep(NA_real_, nrow(raw)))
 
   expect_equal(calculate_anc_prevalence(raw),
                calculate_anc_prevalence(anc_na_known_neg))


### PR DESCRIPTION
This is to fix errors seen from the front end when uploading data without a `births_facility` column. If that column is not set we are getting errors from the ANC data here https://github.com/mrc-ide/naomi/pull/330/files#diff-41ca6a0b90b4c5a022737ba75b3a161ccd69eaa2258feb8cb628ed2bd69733bdR283