### PR TITLE
aggregate_anc() select required columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.7.4
+Version: 2.7.3
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.7.1
+Version: 2.7.4
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.7.4
+
+* Patch `aggregate_anc()`: select required columns when joining to prevent inadvertent column name clash due to extra columns (e.g. `area_level`).
+
 # naomi 2.7.2
 
 * Restructure functions that subset model input data based on logic in model options:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.7.4
 
-* Patch `aggregate_anc()`: select required columns when joining to prevent inadvertent column name clash due to extra columns (e.g. `area_level`).
+* Patch `aggregate_anc()` and `aggregate_art()`: select required columns when joining to prevent inadvertent column name clash due to extra columns (e.g. `area_level`).
 
 # naomi 2.7.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# naomi 2.7.4
+# naomi 2.7.3
 
 * Patch `aggregate_anc()` and `aggregate_art()`: select required columns when joining to prevent inadvertent column name clash due to extra columns (e.g. `area_level`).
 

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -31,7 +31,7 @@ aggregate_art <- function(art, shape) {
   cols_keep <- intersect(cols_list, colnames(art))
 
   art <- art %>%
-    dplyr::select(area_id, sex, age_group, year, calendar_quarter,
+    dplyr::select(area_id, sex, age_group, calendar_quarter,
                   dplyr::any_of(cols_list))
   
   art_number <- art %>%

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -26,6 +26,14 @@ aggregate_art <- function(art, shape) {
     art <- read_art_number(art, all_columns = TRUE)
   }
 
+  # Aggregate based on what columns exist in dataset
+  cols_list <- c("art_current", "art_new", "vl_tested_12mos", "vl_suppressed_12mos")
+  cols_keep <- intersect(cols_list, colnames(art))
+
+  art <- art %>%
+    dplyr::select(area_id, sex, age_group, year, calendar_quarter,
+                  dplyr::any_of(cols_list))
+  
   art_number <- art %>%
     dplyr::left_join(areas %>% dplyr::select(area_id, area_level), by = "area_id") %>%
     dplyr::mutate(year = year_labels(calendar_quarter_to_quarter_id(calendar_quarter)),
@@ -42,10 +50,6 @@ aggregate_art <- function(art, shape) {
     dplyr::left_join(art_number, by = "area_id")
 
 
-  # Aggregate based on what columns exist in dataset
-  cols_list <- c("art_current", "art_new", "vl_tested_12mos", "vl_suppressed_12mos")
-  cols_keep <- intersect(cols_list, colnames(art))
-
   # Function to aggregate based on area_id[0-9]$ columns in hierarchy
   aggregate_data_art <- function(col_name) {
     df <- art_number_wide %>%
@@ -60,10 +64,13 @@ aggregate_art <- function(art, shape) {
   art_long <- grep("^area_id*\\s*[0-9]$", colnames(art_number_wide), value = TRUE) %>%
     lapply(function(x) aggregate_data_art(x))  %>%
     dplyr::bind_rows() %>%
-    dplyr::left_join(areas %>% dplyr::select(area_id, area_name, area_level,
-                                             area_level_label, parent_area_id,
-                                             area_sort_order),
-                     by = "area_id" ) %>%
+    dplyr::left_join(
+      areas %>%
+        dplyr::select(area_id, area_name, area_level,
+                      area_level_label, parent_area_id,
+                      area_sort_order),
+      by = "area_id"
+    ) %>%
     dplyr::select(area_id, area_name, area_level, area_level_label,parent_area_id,
                   area_sort_order, sex, age_group,time_period, year, quarter,
                   calendar_quarter, dplyr::everything()) %>%

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -253,6 +253,13 @@ aggregate_anc <- function(anc, shape) {
     anc <- read_anc_testing(anc)
   }
 
+  ## Select only required columns; to avoid column name clash with
+  ## any additional columns in ANC data set
+  anc <- anc %>%
+    dplyr::select(area_id, age_group, year, anc_clients, anc_known_pos, 
+                  anc_already_art, anc_tested, anc_tested_pos, anc_known_neg, 
+                  births_facility)
+    
   anc_testing <- anc %>%
     dplyr::left_join(areas %>% dplyr::select(area_id, area_level), by = "area_id") %>%
     dplyr::mutate(time_period = as.character(year),

--- a/tests/testthat/test-input-time-series.R
+++ b/tests/testthat/test-input-time-series.R
@@ -316,3 +316,21 @@ test_that("ANC data without births_facility can be aggregated", {
 
   expect_equal(data$births_facility, rep(0, nrow(data)))
 })
+
+test_that("aggregate_anc() discards additional columns", {
+
+  anc <- read_anc_testing(a_hintr_data$anc_testing)
+  anc$area_level <- 4
+
+  data <- aggregate_anc(anc, a_hintr_data$shape)
+  
+  expect_true(nrow(data) > 50) ## Check that we have read out some data
+  expect_setequal(colnames(data),
+                  c("area_id", "area_name", "area_level","area_level_label",
+                    "parent_area_id", "area_sort_order", "sex", "age_group",
+                    "time_period", "year", "quarter", "calendar_quarter",
+                    "anc_clients", "anc_known_pos" , "anc_already_art", "anc_tested",
+                    "anc_tested_pos","anc_known_neg","births_facility", "area_hierarchy"))
+
+
+})

--- a/tests/testthat/test-input-time-series.R
+++ b/tests/testthat/test-input-time-series.R
@@ -317,7 +317,7 @@ test_that("ANC data without births_facility can be aggregated", {
   expect_equal(data$births_facility, rep(0, nrow(data)))
 })
 
-test_that("aggregate_anc() discards additional columns", {
+test_that("aggregate_anc() and aggregate_art() discard additional columns", {
 
   anc <- read_anc_testing(a_hintr_data$anc_testing)
   anc$area_level <- 4
@@ -332,5 +332,14 @@ test_that("aggregate_anc() discards additional columns", {
                     "anc_clients", "anc_known_pos" , "anc_already_art", "anc_tested",
                     "anc_tested_pos","anc_known_neg","births_facility", "area_hierarchy"))
 
+  art <- readr::read_csv(a_hintr_data$art_number)
+  art$area_level <- 4
+  data <- aggregate_art(art, a_hintr_data$shape)
 
+  expect_true(nrow(data) > 100) ## Check that we have read out some data
+  expect_setequal(colnames(data),
+                  c("area_id", "area_name",  "area_level","area_level_label",
+                    "parent_area_id", "area_sort_order", "sex", "age_group",
+                    "time_period", "year", "quarter", "calendar_quarter", "area_hierarchy",
+                    "art_current", "art_new", "vl_tested_12mos", "vl_suppressed_12mos"))
 })


### PR DESCRIPTION
Very small PR to select only the required columns in `aggregate_anc()`. 

This threw an error for some of my South Africa scripts because the ANC data set I was feeding in already had `area_level` and `area_name` included. This caused a column name clash in the joins in `aggregate_anc()`.

 I can change that in those scripts, but I think there is also little harm to be precise about the columns going into the joins, so suggest adding.