### PR TITLE
Translate metadata in download generation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.7.3
+Version: 2.7.4
 Authors@R: 
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.7.4
+
+* Translate quarter label and indicator label in download generation
+
 # naomi 2.7.3
 
 * Patch `aggregate_anc()` and `aggregate_art()`: select required columns when joining to prevent inadvertent column name clash due to extra columns (e.g. `area_level`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.7.4
 
-* Translate quarter label and indicator label in download generation
+* Translate period and indicator metadata when generating output zip
 
 # naomi 2.7.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.7.4
 
-* Translate period and indicator metadata when generating output zip
+* Re-fetch meta data when output zip is generated so that output zip contents in `indicators.csv` and `meta_*.csv` are in the language selected by the user at the time of generation.
 
 # naomi 2.7.3
 

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -961,10 +961,6 @@ save_output <- function(filename, dir,
     yaml::write_yaml(fit$calibration_options, "fit/calibration_options.yml")
   }
 
-  if (!is.null(notes)) {
-
-  }
-
   zip::zipr(path, list.files())
   path
 }

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -518,10 +518,13 @@ add_output_labels <- function(naomi_output, geometry = FALSE) {
     dplyr::select(age_group, age_group_label, age_group_sort_order)
   indicators <- dplyr::left_join(indicators, meta_age_group, by = "age_group")
 
-  indicators <- dplyr::left_join(indicators, naomi_output$meta_period,
-                                 by = "calendar_quarter")
+  indicators$quarter_label <- calendar_quarter_labels(
+    indicators$calendar_quarter)
 
-  meta_indicators <- naomi_output$meta_indicator %>%
+  ## Get meta_indicator fresh instead of from naomi_output object so that we
+  ## use the current set language for the indicator labels instead of
+  ## the language that was used when naomi_output object was created
+  meta_indicators <- get_meta_indicator() %>%
     dplyr::select(indicator, indicator_label, indicator_sort_order)
   indicators <- dplyr::left_join(indicators, meta_indicators, by = "indicator")
 
@@ -616,7 +619,7 @@ add_art_attendance_labels <- function(naomi_output) {
              dplyr::select(age_group, age_group_label, age_group_sort_order),
              by = "age_group"
            ) %>%
-    dplyr::left_join(naomi_output$meta_period, by = "calendar_quarter") %>%
+    dplyr::mutate(quarter_label = calendar_quarter_labels(calendar_quarter)) %>%
     dplyr::arrange(
              reside_area_sort_order,
              attend_area_sort_order,

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -525,9 +525,22 @@ test_that("one input and output for each area_id/age/sex/indicator/period combin
 
 })
 
+test_that("writing output package translates labels", {
+  reset <- naomi_set_language("fr")
+  on.exit(reset())
+  out <- hintr_prepare_spectrum_download(a_hintr_output_calibrated)
 
+  read <- read_output_package(out$path)
+  ## area_level_label comes from input data (not translated)
+  expect_true("Prévalence du VIH" %in% read$indicators$indicator_label)
+  expect_setequal(read$indicators$quarter_label,
+                  c("Mars 2016", "Décembre 2018", "Juin 2019"))
+  ## age group label currently doesn't have translations
+  expect_true("all ages" %in% read$indicators$age_group_label)
 
-
-
+  expect_setequal(read$art_attendance$quarter_label,
+                  c("Mars 2016", "Décembre 2018"))
+  expect_true("all ages" %in% read$art_attendance$age_group_label)
+})
 
 


### PR DESCRIPTION
This PR will
* Refetch the indicator and period metadata when generating output zip so labels are translated

Couple of points here
* We don't currently include sex label in the output table, only the sex values so these are never translated
* We don't currently have any translation for age groups, though the only value which we would need a translation for is "all ages"