### PR TITLE
Add naomi.options to Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,5 @@ Remotes:
     bergant/datamodelr,
     mrc-ide/eppasm,
     first90=mrc-ide/first90release,
-    reside-ic/traduire
+    reside-ic/traduire,
+    mrc-ide/naomi.options


### PR DESCRIPTION
Add dependency naomi.options to "Imports" in DESCRIPTION, since it is not available on CRAN etc.

