### PR TITLE
Fix age barplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.8.8
+Version: 2.8.9
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.8.9
+
+* Fix comparison bar plot error bars and filters.
+
 # naomi 2.8.8
 
 * Update bug in `art_spectrum_warning()` and `anc_spectrum_warning()` where district totals in naomi were compared to national totals in spectrum.

--- a/inst/report/comparison_report.Rmd
+++ b/inst/report/comparison_report.Rmd
@@ -283,8 +283,8 @@ fig2 <- bar_plotly (data,
 
 htmltools::div(
   style = "display: flex; flex-direction: column",
-  htmltools::div(fig1, style = "width: 80%;"),
-  htmltools::div(fig2, style = "width: 80%"),
+  htmltools::div(fig1),
+  htmltools::div(fig2),
 )
 
 ```
@@ -319,8 +319,8 @@ if(is_empty(survey_prev2)) {
 
   htmltools::div(
     style = "display: flex;",
-    htmltools::div(fig1, style = "width: 45%;"),
-    htmltools::div(fig2, style = "width: 45%"),
+    htmltools::div(fig1, style = "width: 50%;"),
+    htmltools::div(fig2, style = "width: 50%"),
   )
 
 } else {
@@ -336,14 +336,14 @@ if(is_empty(survey_prev2)) {
 
   prev_plots <-   htmltools::div(
     style = "display: flex;",
-    htmltools::div(fig1B, style = "width: 45%;"),
-    htmltools::div(fig1, style = "width: 45%"),
+    htmltools::div(fig1B, style = "width: 50%;"),
+    htmltools::div(fig1, style = "width: 50%"),
   )
 
   htmltools::div(
     style = "display: flex; flex-direction: column",
     prev_plots,
-    htmltools::div(fig2, style = "width: 45%")
+    htmltools::div(fig2, style = "width: 50%")
   )
 }
 
@@ -372,8 +372,8 @@ fig2 <- age_bar_plotly (data,
 
   htmltools::div(
     style = "display: flex; flex-direction: column",
-    htmltools::div(fig1, style = "width: 70%"),
-    htmltools::div(fig2, style = "width: 70%")
+    htmltools::div(fig1),
+    htmltools::div(fig2)
     )
 
 ```
@@ -509,14 +509,14 @@ if(has_anc) {
 
   prev_plots <-   htmltools::div(
     style = "display: flex;",
-    htmltools::div(fig1, style = "width: 40%;"),
-    htmltools::div(fig2, style = "width: 40%;")
+    htmltools::div(fig1, style = "width: 50%;"),
+    htmltools::div(fig2, style = "width: 50%;")
   )
 
   art_plots <-   htmltools::div(
     style = "display: flex;",
-    htmltools::div(fig3, style = "width: 40%;"),
-    htmltools::div(fig4, style = "width: 40%;")
+    htmltools::div(fig3, style = "width: 50%;"),
+    htmltools::div(fig4, style = "width: 50%;")
   )
 
   htmltools::div(

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -151,7 +151,7 @@ test_that("comparison report download can be created", {
   expect_length(out$metadata$description, 1)
   expect_equal(out$metadata$areas, "MWI")
 
-  expect_true(file.size(out$path) > 2000)#
+  expect_true(file.size(out$path) > 2000)
   content <- brio::readLines(out$path)
   expect_true(any(grepl("DEMO2016PHIA, DEMO2015DHS", content)))
   expect_true(any(grepl("Naomi estimate CY2016Q1", content)))


### PR DESCRIPTION
There were a couple of issues we saw here
1) The error bars were incorrect
2) Sometimes with e.g. sex "both" filter selected we could see a "male" bar being drawn

Fixed 1) by using a formula for the error, I believe previously it was just showing the same error for every filtered dataset
Fixed 2) this was because the transform does not work with bars split by the "source" factor, the value in the transform was coming from the raw data in order of the raw data, not from the data respecting the factor. I've added a note stating as much

To debug this looking at the generated plotly JSON was the most effective solution. You can get this by using `plotly::plot_json(final_plot)` and then inspecting the data to see where things have gone wrong.