### PR TITLE
Fix art warning copy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.8.8
+Version: 2.8.9
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.8.9
+
+* Don't raise warning for not selecting ART attending when ART data is excluded at T1 and T2
+
 # naomi 2.8.8
 
 * Update bug in `art_spectrum_warning()` and `anc_spectrum_warning()` where district totals in naomi were compared to national totals in spectrum.

--- a/R/model-options.R
+++ b/R/model-options.R
@@ -93,16 +93,19 @@ do_validate_model_options <- function(data, options) {
     }
   }
 
+  # Add warning is ART attendance is not selected
+  if(!(options$artattend == "true")) {
+    if(options$include_art_t1 == "true" || options$include_art_t2 == "true"){
+      naomi_warning(t_("WARNING_OPTIONS_MISSING_ARTATTEND"),
+                    c("model_options"))
+    }
+  }
+
   area_merged <- read_area_merged(data$shape$path)
   if (all(is.na(area_merged$spectrum_region_code))) {
     stop(t_("SHAPE_SPECTRUM_REGION_ALL_NA"))
   }
 
-  # Add warning is ART attendance is not selected
-  if(!(options$artattend == "true")) {
-    naomi_warning(t_("WARNING_OPTIONS_MISSING_ARTATTEND"),
-                  c("model_options"))
-  }
 
   ## ## Validate PJNZ
 

--- a/tests/testthat/test-run-model.R
+++ b/tests/testthat/test-run-model.R
@@ -206,14 +206,12 @@ test_that("exceeding max_iterations raises convergence warning", {
   output_path <- tempfile(fileext = ".qs")
   out <- hintr_run_model(data, options, output_path)
 
-  expect_length(out$warnings, 5)
+  expect_length(out$warnings, 4)
 
   expect_equal(out$warnings[[1]]$text,
-               paste0("You have chosen to fit model without estimating ",
-               "neighbouring ART attendance. You may wish to review your ",
-               "selection to include this option."))
+               paste0("Naomi ART current not equal to Spectrum: 2018 Y000_999 Northern naomi: 78974 spectrum: 57913; 2018 Y000_999 Central naomi: 226728 spectrum: 236140; 2018 Y000_999 Southern naomi: 493159 spectrum: 496708 and 21 more"))
 
-  expect_equal(out$warnings[[5]]$text,
+  expect_equal(out$warnings[[4]]$text,
                paste0("Convergence error: iteration limit reached without convergence (10)"))
 
   msgs <- lapply(out$warnings, function(x) x$text)

--- a/tests/testthat/test-warning.R
+++ b/tests/testthat/test-warning.R
@@ -83,6 +83,15 @@ test_that("warning raised if art attend is not selected", {
                paste0("You have chosen to fit model without estimating ",
                       "neighbouring ART attendance. You may wish to review",
                       " your selection to include this option."))
+
+  # No warning raised when no ART included
+  options_no_art <- options
+  options_no_art$include_art_t1 <- "false"
+  options_no_art$include_art_t2 <- "false"
+
+  out <- validate_model_options(a_hintr_data, options_no_art)
+  expect_length(out$warnings, 0)
+
 })
 
 test_that("warning raised if outputs exceed threshold", {


### PR DESCRIPTION
This PR suppresses the warning raised when users do not select ART attending in model options where no ART data is included.

(New branch copied when #365 git checkout failed)