### PR TITLE
handle multiple .shiny90

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.8.11
+Version: 2.8.12
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.8.12
+
+* Handle case when multiple .shiny90 files found in .PJNZ file. Choose the file with the shortest file name. This will most likely be the file that Spectrum fitter has saved.
+
 # naomi 2.8.11
 
 * Do not attempt to extract .shiny90 data if option `output_aware_plhiv` = "No".

--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -467,7 +467,22 @@ read_spectrum_projection_name <- function(pjnz) {
 
 get_pjnz_shiny90_filename <- function(pjnz) {
   files <- utils::unzip(pjnz, list = TRUE)$Name
-  grep("\\.shiny90$", files, ignore.case = TRUE, value = TRUE)
+  shiny90file <- grep("\\.shiny90$", files, ignore.case = TRUE, value = TRUE)
+
+  if (length(shiny90file) > 1) {
+    msg <- paste0("Multiple .shiny90 files found: ",
+                  paste0(shiny90file, collapse = ", "))
+
+    ## If multiple files found, choose file with shortest name
+    shiny90file <- shiny90file[which.min(nchar(shiny90file))]
+
+    msg <- paste0(msg, "\nUsing file: ", shiny90file)
+
+    ## No need to translate this. It shouldn't happen
+    naomi_warning(msg, c("model_options", "model_fit"))
+  }
+
+  shiny90file
 }
 
 #' Check whether PJNZ contains .shiny90 file

--- a/tests/testthat/test-spectrum.R
+++ b/tests/testthat/test-spectrum.R
@@ -161,3 +161,28 @@ test_that("extract_pjnz_naomi(..., extract_shiny90 = FALSE) returns PLHIV - ART"
 
   expect_equal(spec$unaware, spec$hivpop - spec$artpop)
 })
+
+
+test_that("get_pjnz_shiny90_filename() handles multiple .shiny90 files", {
+
+  pjnz_test <- system_file("extdata/demo_mwi2019_v6.21-shiny90.PJNZ")
+
+  tmpd <- tempfile()
+  shiny90file <- get_pjnz_shiny90_filename(pjnz_test)
+  unzip(pjnz_test, shiny90file, exdir = tmpd)
+
+  shiny90dup <- "Malawi.zip duplicated.shiny90"
+  file.copy(file.path(tmpd, shiny90file), file.path(tmpd, shiny90dup))
+  zip(pjnz_test, file.path(tmpd, shiny90dup), flags = "-j")
+
+  w <- capture_condition(shiny90new <- get_pjnz_shiny90_filename(pjnz_test))
+  
+
+  expect_equal(w$text, "Multiple .shiny90 files found: Malawi.zip.shiny90, Malawi.zip duplicated.shiny90
+Using file: Malawi.zip.shiny90")
+  expect_equal(w$locations, c("model_options", "model_fit"))
+  expect_s3_class(w, "naomi_warning")
+  expect_s3_class(w, "condition")
+
+  expect_equal(shiny90new, "Malawi.zip.shiny90")
+})


### PR DESCRIPTION
Handle case with multiple shiny90 files.

This shouldn't happen (have asked Avenir to patch this). So I think okay to not translate message.