### PR TITLE
Fix generation of comparison report when survey art_coverage year different to t1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.8.15
+Version: 2.8.16
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.8.16
+
+* Don't include ART plots in comparison report download when model fit with an ART calendar quarter different to t1 (issue 41).
+
 # naomi 2.8.15
 
 * Don't include prevalence plots in comparison report download when model fit with survey aggregate data (issue 36).

--- a/inst/report/comparison_report.Rmd
+++ b/inst/report/comparison_report.Rmd
@@ -301,11 +301,18 @@ if (identical(options$use_survey_aggregate, "false")) {
 
 if (!is_empty(options$survey_art_coverage)) {
   ## If no survey ART don't include the plot
-  fig2 <- bar_plotly(data,
-                      ind = "art_coverage",
-                      quarter = calendar_quarter1)
-  plots <- c(plots, list(htmltools::div(fig2)))
-  class <- c(class, "art-barchart")
+  
+  ## Fix for 2022/20223 CMR issue #41
+  filtered_data <- data %>%
+    dplyr::filter(indicator == "art_coverage",
+                  calendar_quarter == calendar_quarter1)
+  if (nrow(filtered_data) > 0) {
+    fig2 <- bar_plotly(data,
+                       ind = "art_coverage",
+                       quarter = calendar_quarter1)
+    plots <- c(plots, list(htmltools::div(fig2)))
+    class <- c(class, "art-barchart")
+  }
 } 
 htmltools::div(plots,
                style = "display: flex; flex-direction: column",
@@ -357,14 +364,17 @@ art_plot <- NULL
 if (!is_empty(options$survey_art_coverage)) {
   
   # ART coverage plot
-  fig2 <-  scatter_plotly(data,
-                          ind = "art_coverage",
-                          quarter = calendar_quarter1,
-                          input_data = survey_art,
-                          input_data_type = "survey")
-  art_plot <- htmltools::div(fig2, 
-                             style = "width: 50%", 
-                             class = "art-scatter")
+  ## Fix for 2022/20223 CMR issue #41
+  if (nrow(filtered_data) > 0) {
+    fig2 <-  scatter_plotly(data,
+                            ind = "art_coverage",
+                            quarter = calendar_quarter1,
+                            input_data = survey_art,
+                            input_data_type = "survey")
+    art_plot <- htmltools::div(fig2, 
+                               style = "width: 50%", 
+                               class = "art-scatter")
+  }
 }
 htmltools::div(
   style = "display: flex; flex-direction: column",
@@ -402,11 +412,15 @@ if (identical(options$use_survey_aggregate, "false")) {
 
 if (!is_empty(options$survey_art_coverage)) {
   ## If no survey ART don't include the plot
-  fig2 <- age_bar_plotly(data,
-                         ind = "art_coverage",
-                         quarter = calendar_quarter1)
-  plots <- c(plots, list(htmltools::div(fig2)))
-  class <- c(class, "art-plotly")
+  
+  ## Fix for 2022/20223 CMR issue #41
+  if (nrow(filtered_data) > 0) {
+    fig2 <- age_bar_plotly(data,
+                           ind = "art_coverage",
+                           quarter = calendar_quarter1)
+    plots <- c(plots, list(htmltools::div(fig2)))
+    class <- c(class, "art-plotly")
+  }
 }
 
 htmltools::div(plots,


### PR DESCRIPTION
The addresses 2022/2023 issue 41 https://teams.microsoft.com/l/message/19:80b58baae16d4f42920e07bffcfcd2a6@thread.tacv2/1674817413252?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=c8a90f50-631c-433e-9927-8aa39ae571fc&parentMessageId=1674817413252&teamName=Naomi%20Support%20-%20WP&channelName=General&createdTime=1674817413252&allowXTenantAccess=false

If there is no data in comparison report plots after filtering on indicator and calendar quarter then it does not attempt to draw the plot. This should address issue of CMR as they have a different ART survey year than their t1