### PR TITLE
Fix translations in download resource descriptions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     knitr,
     magrittr,
     mvtnorm,
-    naomi.options (>= 0.1.5),
+    naomi.options (>= 0.1.6),
     plotly,
     prettyunits,
     qs,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.2
+Version: 2.9.3
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     knitr,
     magrittr,
     mvtnorm,
-    naomi.options (>= 0.1.2),
+    naomi.options (>= 0.1.5),
     plotly,
     prettyunits,
     qs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.8.3
+
+* Fix translation of output descriptions which are used as the resource description for files uploaded to the ADR.
+
 # naomi 2.9.2
 
 * INTERNAL ONLY: Update code to silence warning messages from dplyr v1.1.0. No changes to model or interface.

--- a/R/downloads.R
+++ b/R/downloads.R
@@ -116,15 +116,13 @@ build_description <- function(type_text, options) {
     sprintf("%s - %s", name, value)
   }
   lang <- traduire::translator()$language()
+  labels <- c("OPTIONS_GENERAL_AREA_SCOPE_LABEL",
+            "OPTIONS_GENERAL_AREA_LEVEL_LABEL",
+            "OPTIONS_GENERAL_CALENDAR_QUARTER_T2_LABEL",
+            "OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL")
+  translated_labels <- naomi.options::translate_labels(labels, lang = lang)
   opt_text <- Map(write_options,
-                  c(t_("OPTIONS_GENERAL_AREA_SCOPE_LABEL", language = lang,
-                       package = "naomi.options"),
-                    t_("OPTIONS_GENERAL_AREA_LEVEL_LABEL", language = lang,
-                       package = "naomi.options"),
-                    t_("OPTIONS_GENERAL_CALENDAR_QUARTER_T2_LABEL",
-                       language = lang, package = "naomi.options"),
-                    t_("OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL",
-                       language = lang, package = "naomi.options")),
+                  translated_labels,
                   c(options[["area_scope"]],
                     options[["area_level"]],
                     options[["calendar_quarter_t2"]],

--- a/R/downloads.R
+++ b/R/downloads.R
@@ -98,3 +98,36 @@ hintr_prepare_comparison_report_download <- function(output,
     )
   )
 }
+
+build_output_description <- function(options) {
+  build_description(t_("DOWNLOAD_OUTPUT_DESCRIPTION"), options)
+}
+
+build_summary_report_description <- function(options) {
+  build_description(t_("DOWNLOAD_SUMMARY_DESCRIPTION"), options)
+}
+
+build_comparison_report_description <- function(options) {
+  build_description(t_("DOWNLOAD_COMPARISON_DESCRIPTION"), options)
+}
+
+build_description <- function(type_text, options) {
+  write_options <- function(name, value) {
+    sprintf("%s - %s", name, value)
+  }
+  lang <- traduire::translator()$language()
+  opt_text <- Map(write_options,
+                  c(t_("OPTIONS_GENERAL_AREA_SCOPE_LABEL", language = lang,
+                       package = "naomi.options"),
+                    t_("OPTIONS_GENERAL_AREA_LEVEL_LABEL", language = lang,
+                       package = "naomi.options"),
+                    t_("OPTIONS_GENERAL_CALENDAR_QUARTER_T2_LABEL",
+                       language = lang, package = "naomi.options"),
+                    t_("OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL",
+                       language = lang, package = "naomi.options")),
+                  c(options[["area_scope"]],
+                    options[["area_level"]],
+                    options[["calendar_quarter_t2"]],
+                    options[["calendar_quarter_t3"]]))
+  paste0(c(type_text, "", opt_text), collapse = "\n")
+}

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -232,7 +232,7 @@ run_calibrate <- function(output, calibration_options) {
   ## Only return indicators for T1, T2, T3
   cq_t1t2t3 <- sort(calibrated_output$meta_period$calendar_quarter)[1:3]
   indicators_plot <- dplyr::filter(indicators, calendar_quarter %in% cq_t1t2t3)
-  
+
   list(plot_data = indicators_plot,
        calibrate_data = calibration_data)
 }
@@ -713,34 +713,3 @@ format_options <- function(options) {
 
   options
 }
-
-build_output_description <- function(options) {
-  build_description("Naomi output uploaded from Naomi web app", options)
-}
-
-build_summary_report_description <- function(options) {
-  build_description("Naomi summary report uploaded from Naomi web app",
-                    options)
-}
-
-build_comparison_report_description <- function(options) {
-  build_description("Naomi comparison report uploaded from Naomi web app",
-                    options)
-}
-
-build_description <- function(type_text, options) {
-  write_options <- function(name, value) {
-    sprintf("%s - %s", name, value)
-  }
-  opt_text <- Map(write_options,
-                  c(t_("OPTIONS_GENERAL_AREA_SCOPE_LABEL"),
-                    t_("OPTIONS_GENERAL_AREA_LEVEL_LABEL"),
-                    t_("OPTIONS_GENERAL_CALENDAR_QUARTER_T2_LABEL"),
-                    t_("OPTIONS_OUTPUT_PROJECTION_QUARTER_LABEL")),
-                  c(options[["area_scope"]],
-                    options[["area_level"]],
-                    options[["calendar_quarter_t2"]],
-                    options[["calendar_quarter_t3"]]))
-  paste0(c(type_text, "", opt_text), collapse = "\n")
-}
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,6 @@ RUN install_packages --repo=https://mrc-ide.r-universe.dev \
     pkgbuild \
     testthat.buildkite
 
-RUN install_remote \
-    mrc-ide/naomi.options@mrc-3993-options
-
 ## Model run will try to parallelise over as many threads as are available
 ## potentially slowing the application, manually limit threads to 1
 ENV OMP_NUM_THREADS=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,9 @@ RUN install_packages --repo=https://mrc-ide.r-universe.dev \
     pkgbuild \
     testthat.buildkite
 
+RUN instal_remote \
+    mrc-ide/naomi.options@mrc-3993-options
+
 ## Model run will try to parallelise over as many threads as are available
 ## potentially slowing the application, manually limit threads to 1
 ENV OMP_NUM_THREADS=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN install_packages --repo=https://mrc-ide.r-universe.dev \
     pkgbuild \
     testthat.buildkite
 
-RUN instal_remote \
+RUN install_remote \
     mrc-ide/naomi.options@mrc-3993-options
 
 ## Model run will try to parallelise over as many threads as are available

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -268,5 +268,8 @@
     "UNTREATED_PLHIV_ATTEND": "Untreated PLHIV (ART catchment)",
     "INDICATOR_LABEL_UNTREATED_PLHIV_ATTEND": "Number of untreated PLHIV in area ART catchment",
     "BIRTHS_CLIENTS_RATIO": "Births-clients ratio",
-    "BIRTHS_CLIENTS_RATIO_DESC": "Ratio of births at facility to ANC clients"
+    "BIRTHS_CLIENTS_RATIO_DESC": "Ratio of births at facility to ANC clients",
+    "DOWNLOAD_OUTPUT_DESCRIPTION": "Naomi output uploaded from Naomi web app",
+    "DOWNLOAD_SUMMARY_DESCRIPTION": "Naomi summary report uploaded from Naomi web app",
+    "DOWNLOAD_COMPARISON_DESCRIPTION": "Naomi comparison report uploaded from Naomi web app"
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -268,5 +268,8 @@
     "BIRTHS_CLIENTS_RATIO": "Rapport naissances-clients",
     "BIRTHS_CLIENTS_RATIO_DESC": "Rapport entre le nombre de naissances à l'établissement et le nombre de clients de la CPN",
     "ANC_KNOWN_NEG_DESC": "Nombre de femmes séronégatives en CPN récemment testées et conscientes de leur statut avant la première visite en CPN",
-    "BIRTHS_FACILITY_DESC": "Nombre de naissances dans les établissements de santé"
+    "BIRTHS_FACILITY_DESC": "Nombre de naissances dans les établissements de santé",
+    "DOWNLOAD_OUTPUT_DESCRIPTION": "Paquet Naomi téléchargée depuis l'application web Naomi",
+    "DOWNLOAD_SUMMARY_DESCRIPTION": "Rapport de synthèse Naomi téléchargé depuis l'application web Naomi",
+    "DOWNLOAD_COMPARISON_DESCRIPTION": "Rapport de comparaison Naomi téléchargé à partir de l'application web Naomi"
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -268,5 +268,8 @@
     "BIRTHS_CLIENTS_RATIO": "Relação nascimentos-clientes",
     "BIRTHS_CLIENTS_RATIO_DESC": "Rácio de nascimentos nas instalações para clientes CPN",
     "ANC_KNOWN_NEG_DESC": "Número de participantes de CPN VIH negativos recentemente testados e cientes do status antes da primeira visita de CPN",
-    "BIRTHS_FACILITY_DESC": "Número de nascimentos em estabelecimentos de saúde"
+    "BIRTHS_FACILITY_DESC": "Número de nascimentos em estabelecimentos de saúde",
+    "DOWNLOAD_OUTPUT_DESCRIPTION": "Pacote Naomi descarregado a partir da aplicação web Naomi",
+    "DOWNLOAD_SUMMARY_DESCRIPTION": "Relatório de síntese da Naomi carregado da aplicação web Naomi",
+    "DOWNLOAD_COMPARISON_DESCRIPTION": "Relatório de comparação Naomi carregado a partir da aplicação web Naomi"
 }

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -161,3 +161,16 @@ test_that("comparison report download can be created", {
   expect_equal(messages$progress[[1]]$message,
                "Generating comparison report")
 })
+
+test_that("output description is translated", {
+  text <- build_output_description(a_hintr_options)
+  expect_match(
+    text,
+    "Naomi output uploaded from Naomi web app\\n\\nArea scope - MWI\\n.+")
+
+  reset <- naomi_set_language("fr")
+  on.exit(reset())
+  text <- build_output_description(a_hintr_options)
+  expect_match(text, paste0("Paquet Naomi téléchargée depuis l'application ",
+                            "web Naomi\\n\\nPérimètre de zone - MWI\\n.+"))
+})


### PR DESCRIPTION
This will PR will
* Fix translation of options in the resource description (this regressed since moving the naomi.options out)
* Translate the preamble text


Fixes the issue raised where current description looks like
![image](https://user-images.githubusercontent.com/39248272/219619066-39f512af-eec3-47c3-a6b0-cf2caf6a764d.png)

Note requires https://github.com/mrc-ide/naomi.options/pull/21 to be merged first and then the branch pins removed here