### PR TITLE
Spectrum ART scalar and ETH Datim ID mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.2
+Version: 2.9.3
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.3
+Version: 2.9.4
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.3
+
+* Update PEPFAR Datim UID mapping for CMR.
+
 # naomi 2.9.2
 
 * INTERNAL ONLY: Update code to silence warning messages from dplyr v1.1.0. No changes to model or interface.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.9.4
+
+* Implement Spectrum ART scaling adjustment in Naomi calibration.
+* Add PEPFAR area ID mapping for Ethiopia.
+
 # naomi 2.9.3
 
 * Update PEPFAR Datim UID mapping for CMR.

--- a/inst/datapack/datapack_psnu_area_id_map.csv
+++ b/inst/datapack/datapack_psnu_area_id_map.csv
@@ -293,213 +293,211 @@ CIV,CIV_2_113zy,2,seguela,eoAobHIVIBN,Datim
 CMR,CMR,3,Cameroon,bQQJe0cC1eD,Datim
 CMR,CMR_1_1,4,Adamaoua,xkPoe5mhHE5,Datim
 CMR,CMR_1_2,4,Centre,IaFLxtEwIwk,Datim
-CMR,CMR_1_3,4,Douala,,Datim
-CMR,CMR_1_4,4,Est,KtMNtCHNQDJ,Datim
-CMR,CMR_1_5,4,Extreme Nord,jTLYjaje1D9,Datim
-CMR,CMR_1_6,4,Littoral,MTRiZG58YEx,Datim
-CMR,CMR_1_7,4,Nord,NpJ9e4IC0lg,Datim
-CMR,CMR_1_8,4,Nord Ouest,HxXMyMSODnm,Datim
-CMR,CMR_1_9,4,Ouest,zKL9YsdE5yw,Datim
+CMR,CMR_1_3,4,Est,KtMNtCHNQDJ,Datim
+CMR,CMR_1_4,4,Extreme Nord,jTLYjaje1D9,Datim
+CMR,CMR_1_5,4,Littoral,MTRiZG58YEx,Datim
+CMR,CMR_1_6,4,Nord,NpJ9e4IC0lg,Datim
+CMR,CMR_1_7,4,Nord Ouest,HxXMyMSODnm,Datim
+CMR,CMR_1_8,4,Ouest,zKL9YsdE5yw,Datim
 CMR,CMR_1_10,4,Sud Ouest,Jm3YTCERxvX,Datim
-CMR,CMR_1_11,4,Sud,hsuzPeRTaYP,Datim
-CMR,CMR_1_12,4,Yaoundé               ,,Datim
-CMR,CMR_2_89,5,Abo,VT9tkLtgee9,Datim
-CMR,CMR_2_46,5,Abong Mbang,iTmd0p4YWhK,Datim
-CMR,CMR_2_122,5,Ako,s6P7NGophWH,Datim
-CMR,CMR_2_30,5,Akonolinga,RKsnc4nFUzT,Datim
-CMR,CMR_2_166,5,Akwaya,DoVAXL8t556,Datim
-CMR,CMR_2_183,5,Ambam,lrNc1xwDWXS,Datim
-CMR,CMR_2_23,5,Awae,nbkoU3gPiM0,Datim
-CMR,CMR_2_31,5,Ayos,ZxJNWnk4hYW,Datim
-CMR,CMR_2_140,5,Bafang,KvGZD176fRx,Datim
-CMR,CMR_2_19,5,Bafia,clasYX5teTV,Datim
-CMR,CMR_2_128,5,Bafut,RDEsqpDdyjC,Datim
-CMR,CMR_2_143,5,Baham,TdUjy3VhKQM,Datim
-CMR,CMR_2_172,5,Bakassi,JIQXtxy5dWB,Datim
-CMR,CMR_2_129,5,Bali,pl3EDv60GZ4,Datim
-CMR,CMR_2_130pg,5,Bamenda,cMnkG8Hxa71,Datim
-CMR,CMR_2_191zs,5,Bamenda 3,pz4Uqy8yjga,Datim
-CMR,CMR_2_144,5,Bamendjou,nAVFr0YyPi0,Datim
-CMR,CMR_2_141,5,Bandja,kGF6FW8H5Bk,Datim
-CMR,CMR_2_145,5,Bandjoun,FZdKDla0sab,Datim
-CMR,CMR_2_150,5,Bangangte,ZWsIJYCFqvg,Datim
-CMR,CMR_2_161,5,Bangem,St9lVTJrRaI,Datim
-CMR,CMR_2_151,5,Bangourain,y1pvTD5JtGa,Datim
-CMR,CMR_2_34,5,Bangue,bIoxP4GA2JE,Datim
-CMR,CMR_2_4,5,Bankim,J3p4cfDsjWc,Datim
-CMR,CMR_2_5,5,Banyo,QKxAMfygE74,Datim
-CMR,CMR_2_137,5,Batcham,Slsya4XJ1cX,Datim
-CMR,CMR_2_133,5,Batibo,rucXXEqjQcK,Datim
-CMR,CMR_2_51,5,Batouri,cBrzvNglqAl,Datim
-CMR,CMR_2_192rt,5,Belabo,FI6AAQeYwFH,Datim
-CMR,CMR_2_126,5,Benakuma,W4MLzWKSvB1,Datim
-CMR,CMR_2_55by,5,Bertoua,huRqm1u1OBD,Datim
-CMR,CMR_2_56,5,Betare Oya,QR0Vj8IkvWr,Datim
-CMR,CMR_2_103,5,Bibemi,pg1qjAIJeyF,Datim
-CMR,CMR_2_185,5,Biyem Assi,gOaZeiwAoCD,Datim
-CMR,CMR_2_58,5,Bogo,ms6oiVY4kHA,Datim
-CMR,CMR_2_35,5,Boko,GEWks07uHch,Datim
-CMR,CMR_2_36,5,Bonassama,dWexWkTwCVe,Datim
-CMR,CMR_2_83,5,Bourha,ptBq5K4lAU3,Datim
-CMR,CMR_2_157,5,Buea,dkNG0muACjc,Datim
-CMR,CMR_2_37,5,Cite Des Palmiers,rjDWLPMhaY0,Datim
-CMR,CMR_2_186,5,Cite Verte,NG7DU8YJlw7,Datim
-CMR,CMR_2_193df,5,Dang,lbMwXbGdkil,Datim
-CMR,CMR_2_38,5,Deido,wE76sY8tY19,Datim
-CMR,CMR_2_90,5,Dibombari,VVLMNX1DVin,Datim
-CMR,CMR_2_6,5,Djohong,m6j0i1p3GDw,Datim
-CMR,CMR_2_175,5,Djoum,Lf317dndIqE,Datim
-CMR,CMR_2_187df,5,Djoungolo,vewKgey8sOW,Datim
-CMR,CMR_2_47,5,Doume,Tk1LVQwJYXh,Datim
-CMR,CMR_2_146,5,Dschang,tHav2zlT9YE,Datim
-CMR,CMR_2_12,5,Ebebda,UVkUJt5o0py,Datim
-CMR,CMR_2_179,5,Ebolowa,w3vIrqsfGWS,Datim
-CMR,CMR_2_99,5,Edea,jEG1QQsvDeX,Datim
-CMR,CMR_2_188,5,Efoulan,JQIkiENA6nM,Datim
-CMR,CMR_2_173,5,Ekondo Titi,PtCkWF9WUyM,Datim
-CMR,CMR_2_13,5,Elig Mfomo,sJDHzjIEcte,Datim
-CMR,CMR_2_28,5,Eseka,h7r7vMKQIy8,Datim
-CMR,CMR_2_24,5,Esse,VGZnGAkKRN3,Datim
-CMR,CMR_2_14,5,Evodoula,GFXacOqu8d0,Datim
-CMR,CMR_2_167,5,Eyumodjock,dyB1QMpgHgC,Datim
-CMR,CMR_2_111,5,Figuil,MzAxbEmG17n,Datim
-CMR,CMR_2_164,5,Fontem,a2nQs7VmYiD,Datim
-CMR,CMR_2_65,5,Fotokol,SQVzPECATRQ,Datim
-CMR,CMR_2_152,5,Foumban,fiyChBcsC5L,Datim
-CMR,CMR_2_153,5,Foumbot,VY1XungWEvE,Datim
-CMR,CMR_2_118,5,Fundong,cDNpDbvmp5K,Datim
-CMR,CMR_2_138,5,Galim,zMVbYiRveLp,Datim
-CMR,CMR_2_104,5,Garoua 1,cBl9B9Gr8yM,Datim
-CMR,CMR_2_105,5,GAROUA 2,zDNvh0ltnhO,Datim
-CMR,CMR_2_57,5,Garoua Boulai,D4OFi6ze0sX,Datim
-CMR,CMR_2_106,5,Gaschiga,qaPX93BNxG3,Datim
-CMR,CMR_2_59,5,Gazawa,LiygUBQ6cii,Datim
-CMR,CMR_2_112,5,Golombe,LPNNZUYfC5R,Datim
-CMR,CMR_2_66,5,Goulfey,o6ZCLK6zgCb,Datim
-CMR,CMR_2_73,5,Guere,lA2dnK5pTzs,Datim
-CMR,CMR_2_113,5,Guider,UpWdQLS7yhK,Datim
-CMR,CMR_2_78,5,Guidiguis,aMjjaJXBSlV,Datim
-CMR,CMR_2_84,5,Hina,XtStaOc8r3G,Datim
-CMR,CMR_2_39,5,Japoma,bLF8QVYOUu3,Datim
-CMR,CMR_2_79,5,Kaele,PJ3rdiYvg9h,Datim
-CMR,CMR_2_74,5,Kar Hay,zSSrRr42yh1,Datim
-CMR,CMR_2_142,5,Kekem,OgnR5IaW7OI,Datim
-CMR,CMR_2_52,5,Kette,RIqfYxyxl6s,Datim
-CMR,CMR_2_70,5,Kolofata,WBZN0JbcddP,Datim
-CMR,CMR_2_169,5,Konye,w0khtlIwl6Q,Datim
-CMR,CMR_2_154,5,Kouoptamo,Yy8OR4h9J5x,Datim
-CMR,CMR_2_67,5,Kousseri,Z0Inwzl0go6,Datim
-CMR,CMR_2_85dh,5,Koza,ee7ftYplvV9,Datim
-CMR,CMR_2_181,5,Kribi,JiTDQrmDeYy,Datim
-CMR,CMR_2_170kj,5,Kumba-South,P88XoABjS9G,Datim
-CMR,CMR_2_194ha,5,Kumba-North,MIvAFWhI9Yc,Datim
-CMR,CMR_2_119,5,Kumbo East,VAN2Ql7Bkro,Datim
-CMR,CMR_2_120,5,Kumbo West,cLBRoC6icGa,Datim
-CMR,CMR_2_107,5,Lagdo,RiworzxSRKJ,Datim
-CMR,CMR_2_158,5,Limbe,GP5qeoiXMtA,Datim
-CMR,CMR_2_40,5,Logbaba,ZGqUbMqrxSK,Datim
-CMR,CMR_2_182,5,Lolodorf,xp3usWkmMdg,Datim
-CMR,CMR_2_48,5,Lomie,TIrAQRQkEaH,Datim
-CMR,CMR_2_91,5,Loum,Ns6ZJi0iwJj,Datim
-CMR,CMR_2_68,5,Mada,F78KglHx1Lw,Datim
-CMR,CMR_2_75,5,Maga,NGmNPjCITMZ,Datim
-CMR,CMR_2_69,5,Makary,QmnnpW7Uwm3,Datim
-CMR,CMR_2_155,5,Malentouen,mAXygaodORJ,Datim
-CMR,CMR_2_168,5,Mamfe,zU7eKPwFr69,Datim
-CMR,CMR_2_92,5,Manjo,O4ls7EsyEQP,Datim
-CMR,CMR_2_41,5,Manoka,HAijUCVbjCr,Datim
-CMR,CMR_2_60,5,Maroua 1,AB0dvYIeVs2,Datim
-CMR,CMR_2_61,5,Maroua 2,xeKBtCQWObL,Datim
-CMR,CMR_2_62,5,Maroua 3,baaPQDKEa74,Datim
-CMR,CMR_2_156,5,Massangam,exy7m4TxPrY,Datim
-CMR,CMR_2_114,5,Mayo Oulo,SapRLH9IkZp,Datim
-CMR,CMR_2_32,5,Mbalmayo,haFG5XDW24C,Datim
-CMR,CMR_2_10,5,Mbandjock,bluPTs5StEv,Datim
-CMR,CMR_2_53,5,Mbang,PAM8Jc9FcJS,Datim
-CMR,CMR_2_93,5,Mbanga,nUeu5anINhj,Datim
-CMR,CMR_2_26,5,Mbankomo,VLxcOygmtHk,Datim
-CMR,CMR_2_134,5,Mbengwi,hvNtuMClAXW,Datim
-CMR,CMR_2_171,5,Mbonge,oHNRJzfPFaX,Datim
-CMR,CMR_2_139,5,Mbouda,KE0SetC4PJD,Datim
-CMR,CMR_2_7,5,Meiganga,boMf1Zq6Fa2,Datim
-CMR,CMR_2_94,5,Melong,VFxTcRztfUD,Datim
-CMR,CMR_2_63,5,Meri,xnnHwfGglH2,Datim
-CMR,CMR_2_49,5,Messamena,YS06eYwiC8n,Datim
-CMR,CMR_2_176,5,Meyomessala,MAHWzjJcasB,Datim
-CMR,CMR_2_33,5,Mfou,PJKaNADvNfi,Datim
-CMR,CMR_2_149,5,Mifi,KPgLhnpbXzT,Datim
-CMR,CMR_2_80,5,Mindif,OSXyfij7dGq,Datim
-CMR,CMR_2_86,5,Mogode,l2FDEkk18z2,Datim
-CMR,CMR_2_87,5,Mokolo,Ic2sf6gppTN,Datim
-CMR,CMR_2_44,5,Moloundou,Dcf8i2ih1tm,Datim
-CMR,CMR_2_15,5,Monatele,YXiMSh7CqES,Datim
-CMR,CMR_2_71,5,Mora,jIPFdhfuVCg,Datim
-CMR,CMR_2_81,5,Moulvoudaye,R7G8wdEkwU9,Datim
-CMR,CMR_2_82,5,Moutourwa,Hpc63mRW9IG,Datim
-CMR,CMR_2_195os,5,Mozogo,tIzXjrNeSMQ,Datim
-CMR,CMR_2_174,5,Mundemba,GzuQHLu6ZTN,Datim
-CMR,CMR_2_159,5,Muyuka,jIXZlNwSdG3,Datim
-CMR,CMR_2_180,5,Mvangan,KrnP8YZjfnb,Datim
-CMR,CMR_2_196xd,5,Mvog-Ada,RldLwtXSsvH,Datim
-CMR,CMR_2_11,5,Nanga Eboko,fHkrk3yL1uU,Datim
-CMR,CMR_2_54,5,Ndelele,OLZqeMnDj75,Datim
-CMR,CMR_2_20,5,Ndikinimeki,oAgxCCStCQe,Datim
-CMR,CMR_2_100,5,Ndom,Q966kXsyR20,Datim
-CMR,CMR_2_136,5,Ndop,SeVI9bJFCIZ,Datim
-CMR,CMR_2_123,5,Ndu,AbJXFBhkc4U,Datim
-CMR,CMR_2_42,5,New Bell,k7lIVnxWbm7,Datim
-CMR,CMR_2_101,5,Ngambe,HBG4z9eT0gp,Datim
-CMR,CMR_2_1,5,Ngaoundal,gsAPKvb8uK2,Datim
-CMR,CMR_2_8fg,5,Ngaoundere Rural,YOwUWe1dgJv,Datim
-CMR,CMR_2_9,5,Ngaoundere Urbain,AwlrFJlARNT,Datim
-CMR,CMR_2_29,5,Ngog Mapubi,li3fcQxXdg7,Datim
-CMR,CMR_2_108,5,Ngong,qHwYB0w2vX9,Datim
-CMR,CMR_2_27,5,Ngoumou,qc293v9pKIX,Datim
-CMR,CMR_2_50,5,Nguelemendouka,MHc9aRwt9xv,Datim
-CMR,CMR_2_162,5,Nguti,JIcgSOsSpSV,Datim
-CMR,CMR_2_135,5,Njikwa,HSEc0Cyu0Yy,Datim
-CMR,CMR_2_95,5,Njombe Penja,iwzUigxHuvr,Datim
-CMR,CMR_2_124,5,Nkambe,cbmIcLlVVa1,Datim
-CMR,CMR_2_189,5,Nkolbisson,ThGVWZfLjoq,Datim
-CMR,CMR_2_190pz,5,Nkolndongo,YuCzvkHV2X5,Datim
-CMR,CMR_2_97,5,Nkondjock,oCGhqAOirsv,Datim
-CMR,CMR_2_96,5,Nkongsamba,A0XPpQxn05b,Datim
-CMR,CMR_2_21,5,Ntui,rahoVxbwRB5,Datim
-CMR,CMR_2_125,5,Nwa,o3cdCYbmdmR,Datim
-CMR,CMR_2_43,5,Nylon,AW764lDxjdr,Datim
-CMR,CMR_2_16,5,Obala,r5xWCJ4ZqYQ,Datim
-CMR,CMR_2_197is,5,Odza,hxLso7alVBa,Datim
-CMR,CMR_2_17,5,Okola,hz2Tdvrxqbp,Datim
-CMR,CMR_2_121,5,Oku,s9CiFUWGXnP,Datim
-CMR,CMR_2_184,5,Olamze,P1tSCdEj5Oj,Datim
-CMR,CMR_2_147,5,Penka Michel,vNuXJnxJ0e3,Datim
-CMR,CMR_2_64,5,Pette,hpC7j0T2CaR,Datim
-CMR,CMR_2_109,5,Pitoa,ZJAhq8N1hkR,Datim
-CMR,CMR_2_110,5,Poli,IHFtzOsbuLj,Datim
-CMR,CMR_2_102,5,Pouma,AFX0djkDX6A,Datim
-CMR,CMR_2_115,5,Rey Bouba,xWvGICWwReF,Datim
-CMR,CMR_2_88,5,Roua,EpNF1CgXoSb,Datim
-CMR,CMR_2_18,5,Saa,PLYdjomcBkA,Datim
-CMR,CMR_2_177,5,Sangmelima,o4p0ljHfz8F,Datim
-CMR,CMR_2_131,5,Santa,js5vRAkkqxB,Datim
-CMR,CMR_2_148,5,Santchou,za0SuqfH2S8,Datim
-CMR,CMR_2_25,5,Soa,Vq1CnJNw46x,Datim
-CMR,CMR_2_116,5,Tchollire,rubyTf0wsD9,Datim
-CMR,CMR_2_2,5,Tibati,QN0TvRQr8SA,Datim
-CMR,CMR_2_3,5,Tignere,iwjlpyhilt2,Datim
-CMR,CMR_2_160,5,Tiko,VZPPWeDuJqU,Datim
-CMR,CMR_2_72,5,Tokombere,eealAXfQ3UO,Datim
-CMR,CMR_2_163,5,Tombel,vqaBeYFtUn0,Datim
-CMR,CMR_2_117,5,Touboro,fVcP7WpE6VE,Datim
-CMR,CMR_2_132,5,Tubah,zipfC1pWf1y,Datim
-CMR,CMR_2_76,5,Vele,rTZNA8LtQfx,Datim
-CMR,CMR_2_165,5,Wabane,DWF1ThXXPOB,Datim
-CMR,CMR_2_127,5,Wum,VaHOXJU4rir,Datim
-CMR,CMR_2_98,5,Yabassi,GvTDrgjcU6R,Datim
-CMR,CMR_2_77,5,Yagoua,yFy56LEHSJ4,Datim
-CMR,CMR_2_45,5,Yokadouma,MDZqxU65Lqw,Datim
-CMR,CMR_2_22,5,Yoko,WquO0ev4xvO,Datim
-CMR,CMR_2_178,5,Zoetele,YxZktMjIiey,Datim
+CMR,CMR_1_9,4,Sud,hsuzPeRTaYP,Datim
+CMR,CMR_3_89,5,Abo,VT9tkLtgee9,Datim
+CMR,CMR_3_46,5,Abong Mbang,iTmd0p4YWhK,Datim
+CMR,CMR_3_122,5,Ako,s6P7NGophWH,Datim
+CMR,CMR_3_30,5,Akonolinga,RKsnc4nFUzT,Datim
+CMR,CMR_3_166,5,Akwaya,DoVAXL8t556,Datim
+CMR,CMR_3_183,5,Ambam,lrNc1xwDWXS,Datim
+CMR,CMR_3_23,5,Awae,nbkoU3gPiM0,Datim
+CMR,CMR_3_31,5,Ayos,ZxJNWnk4hYW,Datim
+CMR,CMR_3_140,5,Bafang,KvGZD176fRx,Datim
+CMR,CMR_3_19,5,Bafia,clasYX5teTV,Datim
+CMR,CMR_3_128,5,Bafut,RDEsqpDdyjC,Datim
+CMR,CMR_3_143,5,Baham,TdUjy3VhKQM,Datim
+CMR,CMR_3_172,5,Bakassi,JIQXtxy5dWB,Datim
+CMR,CMR_3_129,5,Bali,pl3EDv60GZ4,Datim
+CMR,CMR_3_130pg,5,Bamenda,cMnkG8Hxa71,Datim
+CMR,CMR_3_191zs,5,Bamenda 3,pz4Uqy8yjga,Datim
+CMR,CMR_3_144,5,Bamendjou,nAVFr0YyPi0,Datim
+CMR,CMR_3_141,5,Bandja,kGF6FW8H5Bk,Datim
+CMR,CMR_3_145,5,Bandjoun,FZdKDla0sab,Datim
+CMR,CMR_3_150,5,Bangangte,ZWsIJYCFqvg,Datim
+CMR,CMR_3_161,5,Bangem,St9lVTJrRaI,Datim
+CMR,CMR_3_151,5,Bangourain,y1pvTD5JtGa,Datim
+CMR,CMR_3_34,5,Bangue,bIoxP4GA2JE,Datim
+CMR,CMR_3_4,5,Bankim,J3p4cfDsjWc,Datim
+CMR,CMR_3_5,5,Banyo,QKxAMfygE74,Datim
+CMR,CMR_3_137,5,Batcham,Slsya4XJ1cX,Datim
+CMR,CMR_3_133,5,Batibo,rucXXEqjQcK,Datim
+CMR,CMR_3_51,5,Batouri,cBrzvNglqAl,Datim
+CMR,CMR_3_192rt,5,Belabo,FI6AAQeYwFH,Datim
+CMR,CMR_3_126,5,Benakuma,W4MLzWKSvB1,Datim
+CMR,CMR_3_55by,5,Bertoua,huRqm1u1OBD,Datim
+CMR,CMR_3_56,5,Betare Oya,QR0Vj8IkvWr,Datim
+CMR,CMR_3_103,5,Bibemi,pg1qjAIJeyF,Datim
+CMR,CMR_3_185,5,Biyem Assi,gOaZeiwAoCD,Datim
+CMR,CMR_3_58,5,Bogo,ms6oiVY4kHA,Datim
+CMR,CMR_3_35,5,Boko,GEWks07uHch,Datim
+CMR,CMR_3_36,5,Bonassama,dWexWkTwCVe,Datim
+CMR,CMR_3_83,5,Bourha,ptBq5K4lAU3,Datim
+CMR,CMR_3_157,5,Buea,dkNG0muACjc,Datim
+CMR,CMR_3_37,5,Cite Des Palmiers,rjDWLPMhaY0,Datim
+CMR,CMR_3_186,5,Cite Verte,NG7DU8YJlw7,Datim
+CMR,CMR_3_193df,5,Dang,lbMwXbGdkil,Datim
+CMR,CMR_3_38,5,Deido,wE76sY8tY19,Datim
+CMR,CMR_3_90,5,Dibombari,VVLMNX1DVin,Datim
+CMR,CMR_3_6,5,Djohong,m6j0i1p3GDw,Datim
+CMR,CMR_3_175,5,Djoum,Lf317dndIqE,Datim
+CMR,CMR_3_187df,5,Djoungolo,vewKgey8sOW,Datim
+CMR,CMR_3_47,5,Doume,Tk1LVQwJYXh,Datim
+CMR,CMR_3_146,5,Dschang,tHav2zlT9YE,Datim
+CMR,CMR_3_12,5,Ebebda,UVkUJt5o0py,Datim
+CMR,CMR_3_179,5,Ebolowa,w3vIrqsfGWS,Datim
+CMR,CMR_3_99,5,Edea,jEG1QQsvDeX,Datim
+CMR,CMR_3_188,5,Efoulan,JQIkiENA6nM,Datim
+CMR,CMR_3_173,5,Ekondo Titi,PtCkWF9WUyM,Datim
+CMR,CMR_3_13,5,Elig Mfomo,sJDHzjIEcte,Datim
+CMR,CMR_3_28,5,Eseka,h7r7vMKQIy8,Datim
+CMR,CMR_3_24,5,Esse,VGZnGAkKRN3,Datim
+CMR,CMR_3_14,5,Evodoula,GFXacOqu8d0,Datim
+CMR,CMR_3_167,5,Eyumodjock,dyB1QMpgHgC,Datim
+CMR,CMR_3_111,5,Figuil,MzAxbEmG17n,Datim
+CMR,CMR_3_164,5,Fontem,a2nQs7VmYiD,Datim
+CMR,CMR_3_65,5,Fotokol,SQVzPECATRQ,Datim
+CMR,CMR_3_152,5,Foumban,fiyChBcsC5L,Datim
+CMR,CMR_3_153,5,Foumbot,VY1XungWEvE,Datim
+CMR,CMR_3_118,5,Fundong,cDNpDbvmp5K,Datim
+CMR,CMR_3_138,5,Galim,zMVbYiRveLp,Datim
+CMR,CMR_3_104,5,Garoua 1,cBl9B9Gr8yM,Datim
+CMR,CMR_3_105,5,GAROUA 2,zDNvh0ltnhO,Datim
+CMR,CMR_3_57,5,Garoua Boulai,D4OFi6ze0sX,Datim
+CMR,CMR_3_106,5,Gaschiga,qaPX93BNxG3,Datim
+CMR,CMR_3_59,5,Gazawa,LiygUBQ6cii,Datim
+CMR,CMR_3_112,5,Golombe,LPNNZUYfC5R,Datim
+CMR,CMR_3_66,5,Goulfey,o6ZCLK6zgCb,Datim
+CMR,CMR_3_73,5,Guere,lA2dnK5pTzs,Datim
+CMR,CMR_3_113,5,Guider,UpWdQLS7yhK,Datim
+CMR,CMR_3_78,5,Guidiguis,aMjjaJXBSlV,Datim
+CMR,CMR_3_84,5,Hina,XtStaOc8r3G,Datim
+CMR,CMR_3_39,5,Japoma,bLF8QVYOUu3,Datim
+CMR,CMR_3_79,5,Kaele,PJ3rdiYvg9h,Datim
+CMR,CMR_3_74,5,Kar Hay,zSSrRr42yh1,Datim
+CMR,CMR_3_142,5,Kekem,OgnR5IaW7OI,Datim
+CMR,CMR_3_52,5,Kette,RIqfYxyxl6s,Datim
+CMR,CMR_3_70,5,Kolofata,WBZN0JbcddP,Datim
+CMR,CMR_3_169,5,Konye,w0khtlIwl6Q,Datim
+CMR,CMR_3_154,5,Kouoptamo,Yy8OR4h9J5x,Datim
+CMR,CMR_3_67,5,Kousseri,Z0Inwzl0go6,Datim
+CMR,CMR_3_85dh,5,Koza,ee7ftYplvV9,Datim
+CMR,CMR_3_181,5,Kribi,JiTDQrmDeYy,Datim
+CMR,CMR_3_170kj,5,Kumba-South,P88XoABjS9G,Datim
+CMR,CMR_3_194ha,5,Kumba-North,MIvAFWhI9Yc,Datim
+CMR,CMR_3_119,5,Kumbo East,VAN2Ql7Bkro,Datim
+CMR,CMR_3_120,5,Kumbo West,cLBRoC6icGa,Datim
+CMR,CMR_3_107,5,Lagdo,RiworzxSRKJ,Datim
+CMR,CMR_3_158,5,Limbe,GP5qeoiXMtA,Datim
+CMR,CMR_3_40,5,Logbaba,ZGqUbMqrxSK,Datim
+CMR,CMR_3_182,5,Lolodorf,xp3usWkmMdg,Datim
+CMR,CMR_3_48,5,Lomie,TIrAQRQkEaH,Datim
+CMR,CMR_3_91,5,Loum,Ns6ZJi0iwJj,Datim
+CMR,CMR_3_68,5,Mada,F78KglHx1Lw,Datim
+CMR,CMR_3_75,5,Maga,NGmNPjCITMZ,Datim
+CMR,CMR_3_69,5,Makary,QmnnpW7Uwm3,Datim
+CMR,CMR_3_155,5,Malentouen,mAXygaodORJ,Datim
+CMR,CMR_3_168,5,Mamfe,zU7eKPwFr69,Datim
+CMR,CMR_3_92,5,Manjo,O4ls7EsyEQP,Datim
+CMR,CMR_3_41,5,Manoka,HAijUCVbjCr,Datim
+CMR,CMR_3_60,5,Maroua 1,AB0dvYIeVs2,Datim
+CMR,CMR_3_61,5,Maroua 2,xeKBtCQWObL,Datim
+CMR,CMR_3_62,5,Maroua 3,baaPQDKEa74,Datim
+CMR,CMR_3_156,5,Massangam,exy7m4TxPrY,Datim
+CMR,CMR_3_114,5,Mayo Oulo,SapRLH9IkZp,Datim
+CMR,CMR_3_32,5,Mbalmayo,haFG5XDW24C,Datim
+CMR,CMR_3_10,5,Mbandjock,bluPTs5StEv,Datim
+CMR,CMR_3_53,5,Mbang,PAM8Jc9FcJS,Datim
+CMR,CMR_3_93,5,Mbanga,nUeu5anINhj,Datim
+CMR,CMR_3_26,5,Mbankomo,VLxcOygmtHk,Datim
+CMR,CMR_3_134,5,Mbengwi,hvNtuMClAXW,Datim
+CMR,CMR_3_171,5,Mbonge,oHNRJzfPFaX,Datim
+CMR,CMR_3_139,5,Mbouda,KE0SetC4PJD,Datim
+CMR,CMR_3_7,5,Meiganga,boMf1Zq6Fa2,Datim
+CMR,CMR_3_94,5,Melong,VFxTcRztfUD,Datim
+CMR,CMR_3_63,5,Meri,xnnHwfGglH2,Datim
+CMR,CMR_3_49,5,Messamena,YS06eYwiC8n,Datim
+CMR,CMR_3_176,5,Meyomessala,MAHWzjJcasB,Datim
+CMR,CMR_3_33,5,Mfou,PJKaNADvNfi,Datim
+CMR,CMR_3_149,5,Mifi,KPgLhnpbXzT,Datim
+CMR,CMR_3_80,5,Mindif,OSXyfij7dGq,Datim
+CMR,CMR_3_86,5,Mogode,l2FDEkk18z2,Datim
+CMR,CMR_3_87,5,Mokolo,Ic2sf6gppTN,Datim
+CMR,CMR_3_44,5,Moloundou,Dcf8i2ih1tm,Datim
+CMR,CMR_3_15,5,Monatele,YXiMSh7CqES,Datim
+CMR,CMR_3_71,5,Mora,jIPFdhfuVCg,Datim
+CMR,CMR_3_81,5,Moulvoudaye,R7G8wdEkwU9,Datim
+CMR,CMR_3_82,5,Moutourwa,Hpc63mRW9IG,Datim
+CMR,CMR_3_195os,5,Mozogo,tIzXjrNeSMQ,Datim
+CMR,CMR_3_174,5,Mundemba,GzuQHLu6ZTN,Datim
+CMR,CMR_3_159,5,Muyuka,jIXZlNwSdG3,Datim
+CMR,CMR_3_180,5,Mvangan,KrnP8YZjfnb,Datim
+CMR,CMR_3_196xd,5,Mvog-Ada,RldLwtXSsvH,Datim
+CMR,CMR_3_11,5,Nanga Eboko,fHkrk3yL1uU,Datim
+CMR,CMR_3_54,5,Ndelele,OLZqeMnDj75,Datim
+CMR,CMR_3_20,5,Ndikinimeki,oAgxCCStCQe,Datim
+CMR,CMR_3_100,5,Ndom,Q966kXsyR20,Datim
+CMR,CMR_3_136,5,Ndop,SeVI9bJFCIZ,Datim
+CMR,CMR_3_123,5,Ndu,AbJXFBhkc4U,Datim
+CMR,CMR_3_42,5,New Bell,k7lIVnxWbm7,Datim
+CMR,CMR_3_101,5,Ngambe,HBG4z9eT0gp,Datim
+CMR,CMR_3_1,5,Ngaoundal,gsAPKvb8uK2,Datim
+CMR,CMR_3_8fg,5,Ngaoundere Rural,YOwUWe1dgJv,Datim
+CMR,CMR_3_9,5,Ngaoundere Urbain,AwlrFJlARNT,Datim
+CMR,CMR_3_29,5,Ngog Mapubi,li3fcQxXdg7,Datim
+CMR,CMR_3_108,5,Ngong,qHwYB0w2vX9,Datim
+CMR,CMR_3_27,5,Ngoumou,qc293v9pKIX,Datim
+CMR,CMR_3_50,5,Nguelemendouka,MHc9aRwt9xv,Datim
+CMR,CMR_3_162,5,Nguti,JIcgSOsSpSV,Datim
+CMR,CMR_3_135,5,Njikwa,HSEc0Cyu0Yy,Datim
+CMR,CMR_3_95,5,Njombe Penja,iwzUigxHuvr,Datim
+CMR,CMR_3_124,5,Nkambe,cbmIcLlVVa1,Datim
+CMR,CMR_3_189,5,Nkolbisson,ThGVWZfLjoq,Datim
+CMR,CMR_3_190pz,5,Nkolndongo,YuCzvkHV2X5,Datim
+CMR,CMR_3_97,5,Nkondjock,oCGhqAOirsv,Datim
+CMR,CMR_3_96,5,Nkongsamba,A0XPpQxn05b,Datim
+CMR,CMR_3_21,5,Ntui,rahoVxbwRB5,Datim
+CMR,CMR_3_125,5,Nwa,o3cdCYbmdmR,Datim
+CMR,CMR_3_43,5,Nylon,AW764lDxjdr,Datim
+CMR,CMR_3_16,5,Obala,r5xWCJ4ZqYQ,Datim
+CMR,CMR_3_197is,5,Odza,hxLso7alVBa,Datim
+CMR,CMR_3_17,5,Okola,hz2Tdvrxqbp,Datim
+CMR,CMR_3_121,5,Oku,s9CiFUWGXnP,Datim
+CMR,CMR_3_184,5,Olamze,P1tSCdEj5Oj,Datim
+CMR,CMR_3_147,5,Penka Michel,vNuXJnxJ0e3,Datim
+CMR,CMR_3_64,5,Pette,hpC7j0T2CaR,Datim
+CMR,CMR_3_109,5,Pitoa,ZJAhq8N1hkR,Datim
+CMR,CMR_3_110,5,Poli,IHFtzOsbuLj,Datim
+CMR,CMR_3_102,5,Pouma,AFX0djkDX6A,Datim
+CMR,CMR_3_115,5,Rey Bouba,xWvGICWwReF,Datim
+CMR,CMR_3_88,5,Roua,EpNF1CgXoSb,Datim
+CMR,CMR_3_18,5,Saa,PLYdjomcBkA,Datim
+CMR,CMR_3_177,5,Sangmelima,o4p0ljHfz8F,Datim
+CMR,CMR_3_131,5,Santa,js5vRAkkqxB,Datim
+CMR,CMR_3_148,5,Santchou,za0SuqfH2S8,Datim
+CMR,CMR_3_25,5,Soa,Vq1CnJNw46x,Datim
+CMR,CMR_3_116,5,Tchollire,rubyTf0wsD9,Datim
+CMR,CMR_3_2,5,Tibati,QN0TvRQr8SA,Datim
+CMR,CMR_3_3,5,Tignere,iwjlpyhilt2,Datim
+CMR,CMR_3_160,5,Tiko,VZPPWeDuJqU,Datim
+CMR,CMR_3_72,5,Tokombere,eealAXfQ3UO,Datim
+CMR,CMR_3_163,5,Tombel,vqaBeYFtUn0,Datim
+CMR,CMR_3_117,5,Touboro,fVcP7WpE6VE,Datim
+CMR,CMR_3_132,5,Tubah,zipfC1pWf1y,Datim
+CMR,CMR_3_76,5,Vele,rTZNA8LtQfx,Datim
+CMR,CMR_3_165,5,Wabane,DWF1ThXXPOB,Datim
+CMR,CMR_3_127,5,Wum,VaHOXJU4rir,Datim
+CMR,CMR_3_98,5,Yabassi,GvTDrgjcU6R,Datim
+CMR,CMR_3_77,5,Yagoua,yFy56LEHSJ4,Datim
+CMR,CMR_3_45,5,Yokadouma,MDZqxU65Lqw,Datim
+CMR,CMR_3_22,5,Yoko,WquO0ev4xvO,Datim
+CMR,CMR_3_178,5,Zoetele,YxZktMjIiey,Datim
 COD,COD,0,Democratic Republic of the Congo,ANN4YCOufcP,Datim
 COD,COD_1_1,1,Bas Uele,CapcQHBO9s0,Datim
 COD,COD_1_2,1,Equateur,pnaIxiu1eiV,Datim

--- a/inst/datapack/datapack_psnu_area_id_map.csv
+++ b/inst/datapack/datapack_psnu_area_id_map.csv
@@ -3730,3 +3730,181 @@ ZWE,ZWE_2_60,2,Kwekwe,KrzWTSmFARO,Datim
 ZWE,ZWE_2_61,2,Mberengwa,vs33LF3cnHy,Datim
 ZWE,ZWE_2_62,2,Shurugwi,XQwyooJ2rFg,Datim
 ZWE,ZWE_2_63,2,Zvishavane,W4O6XMG1LlA,Datim
+ETH,ETH,3,Ethiopia,IH1kchw86uA,Datim
+ETH,ETH_1_10,4,Addis Ababa,KokO4spc5GQ,Datim
+ETH,ETH_1_11,4,Afar,qgDA8IKI21g,Datim
+ETH,ETH_1_12,4,Amhara,LHy7xJAXLWw,Datim
+ETH,ETH_1_13,4,Benishangul-Gumuz,gxiDMS3EAsc,Datim
+ETH,ETH_1_14,4,Dire Dawa,zLhxMpx7wJn,Datim
+ETH,ETH_1_15,4,Gambella,uKcglkRySaR,Datim
+ETH,ETH_1_16,4,Harari,IkyPZgm9R4T,Datim
+ETH,ETH_1_17,4,Oromia,DOVKIHWS3dw,Datim
+ETH,ETH_1_21xz,4,Sidama,HdA88OrFYU6,Datim
+ETH,ETH_1_22pj,4,SNNPR,TKzAS3aEDPE,Datim
+ETH,ETH_1_19,4,Somali,wuoE2SduIfV,Datim
+ETH,ETH_1_23dl,4,South West Ethiopia,Fxt8HwVLcTE,Datim
+ETH,ETH_1_20,4,Tigray,soLrT2pgsfR,Datim
+ETH,ETH_2_001kj,5,Addis Ketema,IrPyq8lcDEX,Datim
+ETH,ETH_2_002,5,Akaki Kality,vWbpmt8WBY4,Datim
+ETH,ETH_2_003,5,Arada,cs4tFtYk5xN,Datim
+ETH,ETH_2_004ej,5,Bole,TNNdsbJravD,Datim
+ETH,ETH_2_005sb,5,Gulele,LHO0q6IL1jy,Datim
+ETH,ETH_2_006,5,Kirkos,s8PbMJU4MQ0,Datim
+ETH,ETH_2_007bi,5,Kolfe Keraniyo,ZNjY2cHBPKG,Datim
+ETH,ETH_2_167hu,5,Lemi Kura,tudl8JRJf2D,Datim
+ETH,ETH_2_008bx,5,Lideta,wm33j9cSswI,Datim
+ETH,ETH_2_009xf,5,Nefas Silk-Lafto,elfhvJK0aTM,Datim
+ETH,ETH_2_010yu,5,Yeka,HC9gzPNLgEp,Datim
+ETH,ETH_2_011,5,Awsi (Zone 1),AJdwBoWSe0W,Datim
+ETH,ETH_2_012,5,Fanti (Zone 4),dhEJ3Fcjx8D,Datim
+ETH,ETH_2_013,5,Gabi (Zone 3),PfLmWBth5y9,Datim
+ETH,ETH_2_014,5,Harri (Zone 5),qaYDXPx3WuW,Datim
+ETH,ETH_2_015,5,Kilbati (Zone 2),gXtidC5DUlC,Datim
+ETH,ETH_2_016,5,Awi,ocAzUvFKBj0,Datim
+ETH,ETH_2_017,5,Bahir Dar Sp. Zone,ORTSIo2wpKu,Datim
+ETH,ETH_2_018,5,Central Gondar,nCASYr3b5MF,Datim
+ETH,ETH_2_168wv,5,Debre Birhan Town,QWeibSkJybw,Datim
+ETH,ETH_2_169xy,5,Debre Markos Town,kCpLmPvaYKl,Datim
+ETH,ETH_2_019,5,Dese Town,WC4dngFLmOd,Datim
+ETH,ETH_2_020so,5,East Gojam,Y9DpmjuMwfm,Datim
+ETH,ETH_2_021,5,Gondar Town,lqLKNDExnbq,Datim
+ETH,ETH_2_170lk,5,Kombolcha Town,czbTdNInpFw,Datim
+ETH,ETH_2_022,5,North Gondar,rxYFVl3VFkU,Datim
+ETH,ETH_2_023rx,5,North Shewa (Amhara),NZVY1yBTyp6,Datim
+ETH,ETH_2_024,5,North Wolo,ovcYzPVUUWI,Datim
+ETH,ETH_2_025,5,Oromiya Zone,KGmy6CUXTRq,Datim
+ETH,ETH_2_026,5,South Gondar,B7ruxHMJB6M,Datim
+ETH,ETH_2_027tt,5,South Wolo,Yvdm19ny7Um,Datim
+ETH,ETH_2_028,5,Wag Himra,gfwHD9a1NO6,Datim
+ETH,ETH_2_029,5,West Gojam,UksOD1lsa0u,Datim
+ETH,ETH_2_030,5,West Gondar,Pcnhcaxuif1,Datim
+ETH,ETH_2_031,5,Assosa,sCoLRakQgke,Datim
+ETH,ETH_2_032,5,Assosa Town,aM09E3nkMU5,Datim
+ETH,ETH_2_033,5,Kemashi,RkYatsMnapn,Datim
+ETH,ETH_2_034,5,Mao Komo Sp. Woreda,uYxO8gaDGil,Datim
+ETH,ETH_2_035,5,Metekel,X1XlInZZBe4,Datim
+ETH,ETH_2_036,5,Dire Dawa Town,CB9pIEeai3U,Datim
+ETH,ETH_2_037,5,Angewak,RVmIVRhx8Y4,Datim
+ETH,ETH_2_038,5,Etang Spe. Woreda,trum80c8biO,Datim
+ETH,ETH_2_039,5,Gambella Town,c5nJPMOo3bO,Datim
+ETH,ETH_2_040,5,Mejenger,EfGhuuc1dC0,Datim
+ETH,ETH_2_041,5,Nuwer,TnEfGrZsKVV,Datim
+ETH,ETH_2_042,5,Harari,msP4OAAYawm,Datim
+ETH,ETH_2_043,5,Adama Town,Hq7l26QbHAU,Datim
+ETH,ETH_2_044,5,Ambo Town,AzCQnXGgts6,Datim
+ETH,ETH_2_045,5,Arsi,afGvs0dpHt2,Datim
+ETH,ETH_2_046,5,Asela Town,ZHOZlqLKuIe,Datim
+ETH,ETH_2_126om,5,Bale,pjaW8X1Ko20,Datim
+ETH,ETH_2_048,5,Batu Town,tE95XAEi8qq,Datim
+ETH,ETH_2_049,5,Bishan Guracha Town,QqwsdoP7fCj,Datim
+ETH,ETH_2_050,5,Bishoftu Town,FSYr4OvAnWJ,Datim
+ETH,ETH_2_051,5,Borena,YMA2KzJPMSY,Datim
+ETH,ETH_2_052,5,Buno Bedele,SmOB12V60lg,Datim
+ETH,ETH_2_053,5,Burayu Town,c5vciSlu23e,Datim
+ETH,ETH_2_054,5,Dukem Town,dych0G4cSKX,Datim
+ETH,ETH_2_125hs,5,East Bale,vQKmOA6jjqq,Datim
+ETH,ETH_2_055,5,East Hararge,tj3Ar6OlXkc,Datim
+ETH,ETH_2_056,5,East Shewa,ZbvD0jFwVKp,Datim
+ETH,ETH_2_057,5,East Welega,SGVs4MLm9wV,Datim
+ETH,ETH_2_058,5,Finfinne Special Zone,s6vyRre6Yt4,Datim
+ETH,ETH_2_059,5,Gelan Town,ssnTVZrwRTw,Datim
+ETH,ETH_2_060,5,Guji,p2hVtS276PB,Datim
+ETH,ETH_2_061,5,Holota Town,lvQxBKnwX90,Datim
+ETH,ETH_2_062,5,Horo Gudru Welega,M8iULGgSqhb,Datim
+ETH,ETH_2_063,5,Ilu Aba Bora,cPO0XR01hKZ,Datim
+ETH,ETH_2_064,5,Jimma,NCJMcvy0nHt,Datim
+ETH,ETH_2_065,5,Jimma Town,x1MDzPVDvmK,Datim
+ETH,ETH_2_066,5,Kelem Welega,xm9S4Vvy8xf,Datim
+ETH,ETH_2_067,5,Lega Tafo Town,uKySbK9FbCs,Datim
+ETH,ETH_2_068,5,Mojo Town,dYUpc7PRZUk,Datim
+ETH,ETH_2_069,5,Nekemte Town,SWVGCwgrvMX,Datim
+ETH,ETH_2_070,5,North Shewa (Oromia),ceOnGaH5r0n,Datim
+ETH,ETH_2_071,5,Robe Town,aXHG80olVqr,Datim
+ETH,ETH_2_072,5,Sebeta Town,cvUxg9nGhyT,Datim
+ETH,ETH_2_073,5,Shashemene Town,N3JudAnE2BV,Datim
+ETH,ETH_2_074,5,South West Shewa,tVBvqbPqjH6,Datim
+ETH,ETH_2_075,5,Sululta Town,P4Jy185ZPvd,Datim
+ETH,ETH_2_076,5,West Arsi,SwUrg0CePwx,Datim
+ETH,ETH_2_077,5,West Guji,Ur0XOQY2HtG,Datim
+ETH,ETH_2_078,5,West Hararge,GIov8P3P62G,Datim
+ETH,ETH_2_079,5,West Shewa,hu1aXuBmkJ2,Datim
+ETH,ETH_2_080,5,West Welega,ou15MoWGZ3k,Datim
+ETH,ETH_2_081,5,Woliso Town,bxyNgtdqhPe,Datim
+ETH,ETH_2_107,5,Afder,JeCVfWOofYF,Datim
+ETH,ETH_2_108,5,Dawo,iytQoFkQjqV,Datim
+ETH,ETH_2_109,5,Dollo (Warder),mW8CJ7BLipn,Datim
+ETH,ETH_2_110,5,Erer,tcOLqU6ieM6,Datim
+ETH,ETH_2_111,5,Fafen (Jijiga),p1gYaXxpyk8,Datim
+ETH,ETH_2_112,5,Jerer (Degahabur),Ao7WsTe6wvO,Datim
+ETH,ETH_2_113,5,Korahe (Keberidehar),ONiP8h437BC,Datim
+ETH,ETH_2_114,5,Liben,I5UvxMgcnNR,Datim
+ETH,ETH_2_115,5,Nogob,OvQquPxd57H,Datim
+ETH,ETH_2_116,5,Shebele (Gode),LO2XhiLb4hI,Datim
+ETH,ETH_2_117,5,Siti (Shinile),UZ8m2bymRJT,Datim
+ETH,ETH_2_118,5,Central Tigray,SCocKNlviny,Datim
+ETH,ETH_2_119,5,Eastern Tigray,pDg8djCo0c1,Datim
+ETH,ETH_2_120,5,Mekele Special Zone,tOt6RC8sphA,Datim
+ETH,ETH_2_121,5,North Western Tigray,XiyYWGTxuSg,Datim
+ETH,ETH_2_165yp,5,South Eastern Tigray,glAvMvEwXql,Datim
+ETH,ETH_2_166vx,5,South Tigray,R5jIPn9DRti,Datim
+ETH,ETH_2_124,5,Western Tigray,YQGDBOiAsny,Datim
+ETH,ETH_2_148ji,5,Aleta Chuko,orAI3YwxWou,Datim
+ETH,ETH_2_147wb,5,Aleta Chuko Town,VBuhjzBhFbO,Datim
+ETH,ETH_2_138ro,5,Aleta Wondo,OzeDEb1NGx8,Datim
+ETH,ETH_2_136ui,5,Aleta Wondo Town,fLUGXJpcbBG,Datim
+ETH,ETH_2_157vn,5,Arbegona,MvS2br5FWRN,Datim
+ETH,ETH_2_158hr,5,Aroresa,fsIf6Dh3R7C,Datim
+ETH,ETH_2_132xl,5,Awasa Zuria,R3kINuTnXKu,Datim
+ETH,ETH_2_162ld,5,Bensa,rO9Ezo9ZBQ2,Datim
+ETH,ETH_2_145zj,5,Bilate Zuria,b6YghAVB7z3,Datim
+ETH,ETH_2_156ug,5,Bona Zuria,MaAYvJxPzx8,Datim
+ETH,ETH_2_146ci,5,Boricha,S2OIBRCLpKW,Datim
+ETH,ETH_2_144xp,5,Bura,tsUYbG4USw7,Datim
+ETH,ETH_2_159jk,5,Bursa,a1pbWIff3gO,Datim
+ETH,ETH_2_143jt,5,Chabe Gambeltu,uTLfZeYvEy7,Datim
+ETH,ETH_2_149hs,5,Chere,TRSvGymYp6f,Datim
+ETH,ETH_2_130nc,5,Chirone,y3BAMl7ya5g,Datim
+ETH,ETH_2_163tl,5,Daela,JizHkcQs67Z,Datim
+ETH,ETH_2_139cx,5,Dale,M7kclECuomB,Datim
+ETH,ETH_2_164gt,5,Dara,SY4mkHZ9v6Q,Datim
+ETH,ETH_2_150tc,5,Dara Otilcho,jnRxemaD4Ho,Datim
+ETH,ETH_2_137qn,5,Darara,NTHFO92QWFd,Datim
+ETH,ETH_2_142pc,5,Daya Town,OnS7zv4sovx,Datim
+ETH,ETH_2_134cg,5,Goreche,kqENDKBOnAR,Datim
+ETH,ETH_2_095,5,Hawassa Town,SSDVixBnw0n,Datim
+ETH,ETH_2_152me,5,Hawella,axeGa2g5J8K,Datim
+ETH,ETH_2_131be,5,Hoko,WitpKwqvSx5,Datim
+ETH,ETH_2_153lg,5,Hula,mNVEj1DdEMV,Datim
+ETH,ETH_2_141mn,5,Leku Town,lWlJCv6bQAA,Datim
+ETH,ETH_2_129ng,5,Loko Abeya,VB2yM4524e2,Datim
+ETH,ETH_2_133xl,5,Malga,HU0olgZslpP,Datim
+ETH,ETH_2_160gg,5,Shafamo,liBgJGTTwku,Datim
+ETH,ETH_2_151ho,5,Shebedino,fxRKUvibHKO,Datim
+ETH,ETH_2_161zj,5,Teticha,KLtCjjVJH1l,Datim
+ETH,ETH_2_140mu,5,Wensho,NRqNrURtame,Datim
+ETH,ETH_2_155wq,5,Wondo Genet,gzzURYR2joc,Datim
+ETH,ETH_2_154cz,5,Wondo Genet Town,fS7IEqWT2nt,Datim
+ETH,ETH_2_135bh,5,Yirga Alem Town,cRFfhS2VNIx,Datim
+ETH,ETH_2_082,5,Alaba Sp. Woreda,WsCJPA73Pfy,Datim
+ETH,ETH_2_127sp,5,Ale (SNNPR) Sp. Zone,bMu3IqXWrFR,Datim
+ETH,ETH_2_084,5,Amaro Sp. Zone,fecMcTJQLGc,Datim
+ETH,ETH_2_085,5,Basketo Sp. Woreda,DUhEMcPxHIH,Datim
+ETH,ETH_2_087,5,Burji Sp. Zone,abtO5wcQbsH,Datim
+ETH,ETH_2_089,5,Dereashe Sp. Zone,E2ErYu25PCJ,Datim
+ETH,ETH_2_090,5,Gamo,w5nkyToNJd4,Datim
+ETH,ETH_2_091,5,Gedeo,MbbwrPZERvl,Datim
+ETH,ETH_2_092,5,Goffa,MJ5Ep2e4eqs,Datim
+ETH,ETH_2_093,5,Gurage,zcW83095pxX,Datim
+ETH,ETH_2_094,5,Hadiya,IDXkfYS25Kt,Datim
+ETH,ETH_2_097,5,Kembata Timbaro,gqsvUCJdCgC,Datim
+ETH,ETH_2_128hj,5,Konso,Efj5yiDDlmT,Datim
+ETH,ETH_2_102,5,Silti,Y21M3gfnCZ8,Datim
+ETH,ETH_2_103,5,South Omo,O5fSSbjRZDh,Datim
+ETH,ETH_2_105,5,Wolayita,jeHPQ7NcxKO,Datim
+ETH,ETH_2_106,5,Yem Sp. Woreda,RkOmuCyrvsT,Datim
+ETH,ETH_2_086,5,Bench Sheko,OpsVFL97XKY,Datim
+ETH,ETH_2_088,5,Dawuro,yHpPnb5CQ7r,Datim
+ETH,ETH_2_096,5,Kefa,AJayqqGyQgl,Datim
+ETH,ETH_2_098,5,Konta Sp. Woreda,JEQrKyALZms,Datim
+ETH,ETH_2_100,5,Sheka,mhp8hJq7zhX,Datim
+ETH,ETH_2_104,5,West Omo,KQOiiwmG4P7,Datim


### PR DESCRIPTION
This PR:

* Implements ART scaling from Spectrum for Naomi calibration. (Affects Uganda; maybe a few other countries will use this week.)
* Adds ID mapping for Ethiopia -> required for Datapack output.
* Updates Datim ID mapping for Cameroon.