### PR TITLE
Render comparison plot when ANC T1 != model T1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.5
+Version: 2.9.6
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.9.6
 
-* Fix for summary report failing to render when ANC data included at T1 in a different year to model T1. This fix will prevent ANC comparison plots from rendering in this case. 
+* Fix for comparison report failing to render when ANC data included at T1 in a different year to model T1. This fix will prevent ANC comparison plots from rendering in this case. 
 
 # naomi 2.9.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.6
+
+* Fix for summary report failing to render when ANC data included at T1 in a different year to model T1. This fix will prevent ANC comparison plots from rendering in this case. 
+
 # naomi 2.9.5
 
 * Fix translation of output descriptions which are used as the resource description for files uploaded to the ADR.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.9.6
 
-* Fix for comparison report failing to render when ANC data included at T1 in a different year to model T1. This fix will prevent ANC comparison plots from rendering in this case. 
+* Fix for comparison report failing to render when ANC data included at T1 in a different year to model T1. This fix will prevent ANC comparison plots for T1 from rendering in this case. 
 
 # naomi 2.9.5
 

--- a/inst/report/comparison_report.Rmd
+++ b/inst/report/comparison_report.Rmd
@@ -563,6 +563,16 @@ if (sum(is.na(programme_data)) <3 ) {
 #-------------------------------------------------------------------------------
 anc_t1 <- outputs$fit$data_options$anc_prev_year_t1
 anc_t2 <- outputs$fit$data_options$anc_prev_year_t2
+
+# Quick fix to prevent ANC plots from rendering if ANC T1 is not in the same year
+# as model T1
+# TO DO: Refactor align_inputs_outputs script to align based on data inclusion 
+# vs. matching on years
+
+if(anc_t1 != naomi:::calendar_quarter_to_year(calendar_quarter1)){
+  anc_t1 <- NULL
+}
+
 has_anc <- !is_empty(anc_t1) && !is_empty(anc_t2)
 
 if (has_anc) {

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -677,3 +677,19 @@ test_that("prevalence survey plots not drawn when using aggregate survey", {
   expect_length(rvest::html_element(html, ".art-scatter"), 0)
   expect_length(rvest::html_element(html, ".art-plotly"), 0)
 })
+
+test_that("can generate comparison report with ANC data at T1 not macthed to model T1", {
+  ## Create a model output with only 1 option chosen for survey_prevalence
+  model_output <- a_hintr_output_calibrated$model_output_path
+  output <- qs::qread(model_output)
+  options <- yaml::read_yaml(text = output$info$options.yml)
+  options$anc_prevalence_year1 <- "2017"
+  options$anc_art_coverage_year1 <- "2017"
+  output$info$options.yml <- yaml::as.yaml(options)
+  out <- tempfile(fileext = ".qs")
+  model_output <- qs::qsave(output, preset = "fast", out)
+
+  t <- tempfile(fileext = ".html")
+  generate_comparison_report(t, out, quiet = TRUE)
+  expect_true(file.size(t) > 2000)
+})


### PR DESCRIPTION
Quick fix to prevent ANC plots from rendering if ANC T1 is not in the same year as model T1
TO DO: Refactor align_inputs_outputs script to align based on data inclusion vs. matching on years