### PR TITLE
Explictly state spdep::nb2listw style argument, to avoid warning

### DIFF
--- a/R/car.R
+++ b/R/car.R
@@ -74,7 +74,7 @@ scale_gmrf_precision <- function(Q,
                                  A = matrix(1, ncol = ncol(Q)),
                                  eps = sqrt(.Machine$double.eps)) {
 
-  nb <- spdep::mat2listw(abs(Q))$neighbours
+  nb <- spdep::mat2listw(abs(Q), style = "B")$neighbours
   comp <- spdep::n.comp.nb(nb)
 
   for (k in seq_len(comp$nc)) {


### PR DESCRIPTION
Actually using `spdep::mat2listw`, not `spdep::nb2listw`!