### PR TITLE
correct ART need 15plus for Spectrum 2023

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.9
+Version: 2.9.10
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naomi 2.9.10
+
+* Update PJNZ extraction for adult ART need Dec 31 for 2023 PJNZ files. Previously child ART was
+  note recorded in the .DP file tag `<NeedARTDec31 MV>`, and so it was fine to extract the total
+  value. Now child ART is recorded, and so need to sum the adult age groups only.
+
 # naomi 2.9.9
 
 * Add indicators `aware_plhiv_attend` and `unaware_plhiv_attend` for consistent facility attendance cascades.

--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -183,9 +183,19 @@ read_dp_art_dec31 <- function(dp) {
   art15plus_num <- sapply(dpsub("<HAARTBySex MV>", 4:5, timedat.idx), as.numeric)
   dimnames(art15plus_num) <- list(sex = c("male", "female"), year = proj.years)
 
-  art15plus_need <- sapply(dpsub("<NeedARTDec31 MV>", 3:4, timedat.idx), as.numeric)
+  ## In Spectrum 2023, "<NeedARTDec31 MV>" was updated to include children in the totals
+  ## -> now need to sum over 5-year age groups for age 15+ to get the adult ART need
+  
+  male_15plus_needart <- dpsub("<NeedARTDec31 MV>", 4:17*3 + 3, timedat.idx)
+  male_15plus_needart <- vapply(lapply(male_15plus_needart, as.numeric), sum, numeric(1))
+
+  female_15plus_needart <- dpsub("<NeedARTDec31 MV>", 4:17*3 + 4, timedat.idx)
+  female_15plus_needart <- vapply(lapply(female_15plus_needart, as.numeric), sum, numeric(1))
+
+  art15plus_need <- rbind(male_15plus_needart, female_15plus_needart)
   dimnames(art15plus_need) <- list(sex = c("male", "female"), year = proj.years)
 
+  
   if (any(art15plus_num[art15plus_isperc == 1] < 0 |
           art15plus_num[art15plus_isperc == 1] > 100)) {
     stop("Invalid percentage on ART entered for adult ART")


### PR DESCRIPTION
Spectrum did an internal change that affects how ART data are recorded in the projection period. This fixes that.