### PR TITLE
Reduce number of indicators returned in plotting data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.10
+Version: 2.9.11
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.9.11
+
+* Remove ANC and population indicator from plot data to reduce download size for web front end
+* Remove time 3 data for DRC to temporarily reduce the download size for web front end
+
 # naomi 2.9.10
 
 * Update PJNZ extraction for adult ART need Dec 31 for 2023 PJNZ files. Previously child ART was

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -229,9 +229,19 @@ run_calibrate <- function(output, calibration_options) {
   output_naomi_warning(calibrated_output, "art_coverage", 1,
                        c("model_calibrate","review_output", "download_results"))
 
-  ## Only return indicators for T1, T2, T3
+  ## Only return calendar quarters T1, T2, T3 and target setting indicators
+  ## for plotting
+  ## TODO: We should ideally save all data out here and manage splitting this
+  ## for the web app in API layer. But at the moment we return all data in
+  ## one big request, so we need to limit its size for performance.
   cq_t1t2t3 <- sort(calibrated_output$meta_period$calendar_quarter)[1:3]
-  indicators_plot <- dplyr::filter(indicators, calendar_quarter %in% cq_t1t2t3)
+  exclude_indicators <- c(
+    "anc_prevalence", "anc_art_coverage", "anc_clients", "anc_plhiv",
+    "anc_already_art", "anc_art_new", "anc_known_pos", "anc_tested_pos",
+    "anc_tested_neg", "population")
+  indicators_plot <- dplyr::filter(indicators,
+                                   calendar_quarter %in% cq_t1t2t3 &
+                                     !(indicator %in% exclude_indicators))
 
   list(plot_data = indicators_plot,
        calibrate_data = calibration_data)

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -234,17 +234,27 @@ run_calibrate <- function(output, calibration_options) {
   ## TODO: We should ideally save all data out here and manage splitting this
   ## for the web app in API layer. But at the moment we return all data in
   ## one big request, so we need to limit its size for performance.
-  cq_t1t2t3 <- sort(calibrated_output$meta_period$calendar_quarter)[1:3]
+  cq_keep <- sort(calibrated_output$meta_period$calendar_quarter)[1:3]
+  browser()
+  iso3 <- get_iso3_from_meta_area(calibrated_output$meta_area)
+  if (length(iso3) > 0 && iso3 == "COD") {
+    t3 <- calibrated_output$fit$model_options$calendar_quarter_t3
+    cq_keep <- cq_keep[cq_keep != t3]
+  }
   exclude_indicators <- c(
     "anc_prevalence", "anc_art_coverage", "anc_clients", "anc_plhiv",
     "anc_already_art", "anc_art_new", "anc_known_pos", "anc_tested_pos",
     "anc_tested_neg", "population")
   indicators_plot <- dplyr::filter(indicators,
-                                   calendar_quarter %in% cq_t1t2t3 &
+                                   calendar_quarter %in% cq_keep &
                                      !(indicator %in% exclude_indicators))
 
   list(plot_data = indicators_plot,
        calibrate_data = calibration_data)
+}
+
+get_iso3_from_meta_area <- function(meta_area) {
+  meta_area[meta_area$area_level == 0, ]$area_id
 }
 
 #' Get id to label mapping for calibration plot data type

--- a/tests/testthat/test-01-run-model.R
+++ b/tests/testthat/test-01-run-model.R
@@ -307,7 +307,7 @@ test_that("model run can be calibrated", {
   ## Output has been calibrated
   expect_true(!is.null(calibrated_output$plot_data_path))
   calibrated_output_obj <- read_hintr_output(calibrated_output$model_output_path)
-  
+
   ## Total population outputs:
   ## * 33 age groups
   ## * 3 sexes
@@ -323,11 +323,12 @@ test_that("model run can be calibrated", {
   ## 12 = number of ANC age groups
   expect_equal(nrow(calibrated_output_obj$output_package$indicators),
                33 * 3 * 9 * (3 * 16 + 1 * 5 + 1 * 4) + 3 * 9 * 9 * 12)
-  
+
   ## Plot data output: T3 and T4 indicators not included -> fewer rows
-  plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)  
+  ## Also excluded ANC indicator outputs and population
+  plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)
   expect_equal(nrow(plot_data_output),
-               33 * 3 * 9 * (3 * 16 + 0 * 5 + 0 * 4) + 3 * 9 * 9 * 12)
+               33 * 3 * 9 * (3 * 15 + 0 * 5 + 0 * 4))
 
   expect_file_different(calibrated_output$model_output_path,
                         a_hintr_output$model_output_path)

--- a/tests/testthat/test-01-run-model.R
+++ b/tests/testthat/test-01-run-model.R
@@ -324,7 +324,7 @@ test_that("model run can be calibrated", {
   expect_equal(nrow(calibrated_output_obj$output_package$indicators),
                33 * 3 * 9 * (3 * 16 + 1 * 5 + 1 * 4) + 3 * 9 * 9 * 12)
 
-  ## Plot data output: T3 and T4 indicators not included -> fewer rows
+  ## Plot data output: T4 and T5 indicators not included -> fewer rows
   ## Also excluded ANC indicator outputs and population
   plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)
   expect_equal(nrow(plot_data_output),
@@ -361,6 +361,34 @@ test_that("model run can be calibrated", {
   expect_error(
     hintr_calibrate(calibrated_output, calibration_options),
     "Calibration cannot be re-run for this model fit please re-run fit step.")
+})
+
+test_that("plotting data excludes t3 for DRC", {
+  ## TODO: This is temporary until we can deal with bigger data in the
+  ## front end
+  plot_data_path <- tempfile(fileext = ".qs")
+  calibration_output_path <- tempfile(fileext = ".qs")
+  mockery::stub(hintr_calibrate, "get_iso3_from_meta_area", "COD", depth = 2)
+  calibrated_output <- hintr_calibrate(a_hintr_output,
+                                       a_hintr_calibration_options,
+                                       plot_data_path,
+                                       calibration_output_path)
+
+  expect_s3_class(calibrated_output, "hintr_output")
+  expect_equal(calibrated_output$plot_data_path, plot_data_path)
+  expect_true(!is.null(calibrated_output$plot_data_path))
+
+  ## Total outputs:
+  ## * 33 age groups
+  ## * 3 sexes
+  ## * 9 areas
+  ## * 2 output times
+  ## * 15 indicators
+  ## Plot data output: T3, T4 & T5 indicators not included -> fewer rows
+  ## Also excluded ANC indicator outputs and population
+  plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)
+  expect_equal(nrow(plot_data_output),
+               33 * 3 * 9 * 2 * 15)
 })
 
 test_that("calibrating model with 'none' returns same results", {


### PR DESCRIPTION
We've seen the plotting data returned to the front end for DRC growing too big and it causing issues with transfer and serializing times. Serializing to json taking about 35s and data transfer can take several minutes which is causing problems for people on slower connections. The serialized json is going to 600MB which is too big for a single response. This PR puts in a temporary fix to cut down the number of indicators returned, eventually we will split this data transfer up instead to send a request to get plotting data for each indicator/time separately. But this is a quick fix for now.