### PR TITLE
mrc-4555: Add ability to save hintr output as duckdb database

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.10
+Version: 2.9.11
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",
@@ -17,6 +17,7 @@ RoxygenNote: 7.2.1
 Additional_repositories:
     https://mrc-ide.r-universe.dev
 Imports:
+    DBI,
     Matrix,
     R6,
     TMB,
@@ -24,6 +25,7 @@ Imports:
     brio,
     data.tree,
     dplyr (>= 1.1.0),
+    duckdb,
     eppasm (>= 0.7.1),
     first90 (>= 1.6.1),
     forcats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.11
+
+* hintr data frame outputs can now be saved as a duckdb database.
+
 # naomi 2.9.10
 
 * Update PJNZ extraction for adult ART need Dec 31 for 2023 PJNZ files. Previously child ART was

--- a/R/Lproj.R
+++ b/R/Lproj.R
@@ -254,7 +254,8 @@ create_Lproj <- function(spec, mf_model,
     dplyr::inner_join(
       dplyr::select(mf_model, spectrum_region_code, sex, age_group_infection = age_group, area_id, idx1 = idx),
       by = c("spectrum_region_code", "sex", "age_group_infection"),
-      multiple = "all"
+      multiple = "all",
+      relationship = "many-to-many"
     ) %>%
     dplyr::inner_join(
       dplyr::select(mf_model, spectrum_region_code, sex, age_group2 = age_group, area_id, idx2 = idx),

--- a/R/Lproj.R
+++ b/R/Lproj.R
@@ -197,7 +197,8 @@ create_Lproj <- function(spec, mf_model,
     dplyr::inner_join(
       dplyr::select(mf_model, spectrum_region_code, sex, age_group1 = age_group, area_id, idx1 = idx),
       by = c("spectrum_region_code", "sex", "age_group1"),
-      multiple = "all"
+      multiple = "all",
+      relationship = "many-to-many"
     ) %>%
     dplyr::inner_join(
       dplyr::select(mf_model, spectrum_region_code, sex, age_group2 = age_group, area_id, idx2 = idx),
@@ -245,7 +246,8 @@ create_Lproj <- function(spec, mf_model,
 
   incidLproj <- infections_age_t2 %>%
     dplyr::left_join(infections_age_1year,
-                     by = c("spectrum_region_code", "sex", "age_group_infection")) %>%
+                     by = c("spectrum_region_code", "sex", "age_group_infection"),
+                     relationship = "many-to-many") %>%
     dplyr::mutate(
       L_incid = dplyr::if_else(infections_age == 0, 0, infections_age_t2 / infections_age)
     ) %>%
@@ -290,7 +292,8 @@ create_Lproj <- function(spec, mf_model,
         ) %>%
         dplyr::select(spectrum_region_code, sex1 = sex, age_group1, hivpop1),
       by = "spectrum_region_code",
-      multiple = "all"
+      multiple = "all",
+      relationship = "many-to-many"
     ) %>%
     dplyr::group_by(spectrum_region_code, sex2, age_group2) %>%
     dplyr::mutate(L_paed = hivpop2 / sum(hivpop1)) %>%
@@ -301,7 +304,8 @@ create_Lproj <- function(spec, mf_model,
       dplyr::select(mf_model, spectrum_region_code, sex1 = sex,
                     age_group1 = age_group, area_id, idx1 = idx),
       by = c("spectrum_region_code", "sex1", "age_group1"),
-      multiple = "all"
+      multiple = "all",
+      relationship = "many-to-many"
     ) %>%
     dplyr::inner_join(
       dplyr::select(mf_model, spectrum_region_code, sex2 = sex,

--- a/R/areas.R
+++ b/R/areas.R
@@ -17,7 +17,7 @@
 #' areas
 #'
 #' @export
-  create_areas <- function(levels = NULL, hierarchy = NULL, boundaries = NULL,
+create_areas <- function(levels = NULL, hierarchy = NULL, boundaries = NULL,
                          area_merged = NULL) {
 
   if(is.null(area_merged) &&
@@ -255,7 +255,7 @@ get_area_collection <- function(areas, level = NULL, area_scope = NULL) {
 create_area_aggregation <- function(model_area_ids, areas, drop_partial_areas = TRUE) {
 
   stopifnot(methods::is(areas, "naomi_areas"))
-  
+
   area_id_out <- areas$tree$Get("area_id",
                                 traversal = "level")
   area_id_out_leaves <- areas$tree$Get("leaves",
@@ -266,7 +266,7 @@ create_area_aggregation <- function(model_area_ids, areas, drop_partial_areas = 
   area_id_out <- area_id_out[!duplicated(area_id_out)]
 
   stopifnot(model_area_ids %in% unlist(area_id_out_leaves))
-  
+
   leaf_in_model <- lapply(area_id_out_leaves, `%in%`, model_area_ids)
   if(drop_partial_areas) {
     all_leaves_in_model <- vapply(leaf_in_model, all, logical(1))

--- a/R/hintr-plot-data.R
+++ b/R/hintr-plot-data.R
@@ -23,7 +23,7 @@ hintr_calibrate_plot <- function(output) {
   ## Only return indicators for T1, T2, T3
   cq_t1t2t3 <- sort(calibration_data$output_package$meta_period$calendar_quarter)[1:3]
   df <- dplyr::filter(df, calendar_quarter %in% cq_t1t2t3)
-  
+
   dflong <- df %>%
     dplyr::mutate(population_denominator = population_calibrated) %>%
     tidyr:: pivot_longer(c(tidyselect::ends_with("raw"),
@@ -91,9 +91,12 @@ hintr_calibrate_plot <- function(output) {
     dplyr::select(age_group_out, age_group)
 
   dfexpand <- dflong %>%
-    dplyr::inner_join(region_out, by = "spectrum_region_code", multiple = "all") %>%
-    dplyr::inner_join(sex_join, by = "sex", multiple = "all") %>%
-    dplyr::inner_join(age_group_join, by = "age_group", multiple = "all") %>%
+    dplyr::inner_join(region_out, by = "spectrum_region_code", multiple = "all",
+                      relationship = "many-to-many") %>%
+    dplyr::inner_join(sex_join, by = "sex", multiple = "all",
+                      relationship = "many-to-many") %>%
+    dplyr::inner_join(age_group_join, by = "age_group", multiple = "all",
+                      relationship = "many-to-many") %>%
     dplyr::count(spectrum_region_code = spectrum_region_code_out,
                  spectrum_region_name = spectrum_region_name_out,
                  sex = sex_out,

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1216,7 +1216,8 @@ disaggregate_0to4_outputs <- function(output, naomi_mf) {
     dplyr::inner_join(
              naomi_mf$spectrum_0to4distribution,
              by = c("spectrum_region_code", "calendar_quarter", "indicator"),
-             multiple = "all"
+             multiple = "all",
+             relationship = "many-to-many"
            ) %>%
     dplyr::mutate(mean_strat = mean * distribution) %>%
     dplyr::select(area_id, sex, age_group, calendar_quarter, indicator, mean_strat)
@@ -1241,7 +1242,8 @@ disaggregate_0to4_outputs <- function(output, naomi_mf) {
     dplyr::select(area_id, sex, area_id_out, sex_out)
 
   strat_mean_counts_out <- strat_mean_counts_model %>%
-    dplyr::left_join(A_0to4_long, by = c("area_id", "sex"), multiple = "all") %>%
+    dplyr::left_join(A_0to4_long, by = c("area_id", "sex"), multiple = "all",
+                     relationship = "many-to-many") %>%
     dplyr::count(area_id = area_id_out, sex = sex_out, age_group, calendar_quarter, indicator,
                  wt = mean_strat, name = "distribution") %>%
     dplyr::group_by(area_id, sex, calendar_quarter, indicator) %>%
@@ -1250,7 +1252,9 @@ disaggregate_0to4_outputs <- function(output, naomi_mf) {
 
   out_0to4strat_counts <- out0to4 %>%
     dplyr::inner_join(strat_mean_counts_out,
-                      by = c("area_id", "sex", "calendar_quarter", "indicator"), multiple = "all") %>%
+                      by = c("area_id", "sex", "calendar_quarter", "indicator"),
+                      multiple = "all",
+                      relationship = "many-to-many") %>%
     tidyr::pivot_longer(c(mean, se, median, mode, lower, upper)) %>%
     dplyr::mutate(value = value * distribution,
                   distribution = NULL) %>%

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1331,9 +1331,12 @@ read_hintr_output <- function(path) {
     qs::qread(path)
   } else if (type == "duckdb") {
     read_duckdb(path)
-  } else {
+  } else if (type == "rds") {
     ## Model & plot data output before v2.8.0 were saved as RDS
     readRDS(path)
+  } else {
+    stop(sprintf(paste("Cannot read hintr data of invalid type, got '%s',",
+                       "must be one of rds, qs or duckdb."), type))
   }
 }
 

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -118,7 +118,7 @@ extract_indicators <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
                      "plhiv_t5_out" = "plhiv",
                      "plhiv_attend_t5_out" = "plhiv_attend",
                      "infections_t5_out" = "infections")
-  
+
   if (naomi_mf$output_aware_plhiv) {
 
     indicators_t1 <- c(indicators_t1,
@@ -145,14 +145,14 @@ extract_indicators <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
   indicator_est_t2 <- Map(get_est, names(indicators_t2), indicators_t2, naomi_mf$calendar_quarter2)
   indicator_est_t3 <- Map(get_est, names(indicators_t3), indicators_t3, naomi_mf$calendar_quarter3)
   indicator_est_t4 <- Map(get_est, names(indicators_t4), indicators_t4, naomi_mf$calendar_quarter4)
-  indicator_est_t5 <- Map(get_est, names(indicators_t5), indicators_t5, naomi_mf$calendar_quarter5)  
-  
+  indicator_est_t5 <- Map(get_est, names(indicators_t5), indicators_t5, naomi_mf$calendar_quarter5)
+
 
   indicator_est_t1 <- dplyr::bind_rows(indicator_est_t1)
   indicator_est_t2 <- dplyr::bind_rows(indicator_est_t2)
   indicator_est_t3 <- dplyr::bind_rows(indicator_est_t3)
   indicator_est_t4 <- dplyr::bind_rows(indicator_est_t4)
-  indicator_est_t5 <- dplyr::bind_rows(indicator_est_t5)  
+  indicator_est_t5 <- dplyr::bind_rows(indicator_est_t5)
 
   indicators_anc_t1 <- c("anc_clients_t1_out" = "anc_clients",
                          "anc_plhiv_t1_out" = "anc_plhiv",
@@ -210,7 +210,7 @@ extract_indicators <- function(naomi_fit, naomi_mf, na.rm = FALSE) {
                   indicator_est_t3,
                   indicator_anc_est_t3,
                   indicator_est_t4,
-                  indicator_est_t5                  
+                  indicator_est_t5
                 )
 
   dplyr::select(out, names(naomi_mf$mf_out),
@@ -1322,10 +1322,21 @@ get_period_metadata <- function(calendar_quarters) {
 #' @return The read data
 #' @export
 read_hintr_output <- function(path) {
-  if (tolower(tools::file_ext(path)) == "qs") {
+  type <- tolower(tools::file_ext(path))
+  if (type == "qs") {
     qs::qread(path)
+  } else if (type == "duckdb") {
+    read_duckdb(path)
   } else {
     ## Model & plot data output before v2.8.0 were saved as RDS
     readRDS(path)
   }
 }
+
+read_duckdb <- function(path) {
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = path)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+  DBI::dbGetQuery(con, sprintf("SELECT * from %s", DUCKDB_OUTPUT_TABLE_NAME))
+}
+
+

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -96,7 +96,9 @@ prepare_tmb_inputs <- function(naomi_data,
 
   df_art_attend <- naomi_data$mf_model %>%
     dplyr::rename(reside_area_id = area_id) %>%
-    dplyr::left_join(naomi_data$mf_artattend, by = "reside_area_id", multiple = "all") %>%
+    dplyr::left_join(naomi_data$mf_artattend, by = "reside_area_id",
+                     multiple = "all",
+                     relationship = "many-to-many") %>%
     dplyr::mutate(attend_idf = forcats::as_factor(attend_idx),
                   idf = forcats::as_factor(idx))
 
@@ -156,7 +158,7 @@ prepare_tmb_inputs <- function(naomi_data,
   X_paed_lambda_ratio_t2 <- sparse_model_matrix(~-1 + area_idf:paed_lambda_ratio_t2, df)
   X_paed_lambda_ratio_t3 <- sparse_model_matrix(~-1 + area_idf:paed_lambda_ratio_t3, df)
   X_paed_lambda_ratio_t4 <- sparse_model_matrix(~-1 + area_idf:paed_lambda_ratio_t4, df)
-  X_paed_lambda_ratio_t5 <- sparse_model_matrix(~-1 + area_idf:paed_lambda_ratio_t5, df)  
+  X_paed_lambda_ratio_t5 <- sparse_model_matrix(~-1 + area_idf:paed_lambda_ratio_t5, df)
 
   f_rho_a <- if(all(is.na(df$rho_a_fct))) ~0 else ~0 + rho_a_fct
   f_alpha_a <- if(all(is.na(df$alpha_a_fct))) ~0 else ~0 + alpha_a_fct
@@ -403,7 +405,7 @@ prepare_tmb_inputs <- function(naomi_data,
     Lproj_incid_t4t5 = naomi_data$Lproj_t4t5$Lproj_incid,
     Lproj_paed_t4t5 = naomi_data$Lproj_t4t5$Lproj_paed,
     logit_alpha_t4t5_offset = df$logit_alpha_t4t5_offset,
-    log_lambda_t5_offset = df$log_lambda_t5_offset,    
+    log_lambda_t5_offset = df$log_lambda_t5_offset,
     ##
     A_out = naomi_data$A_out,
     A_anc_out = naomi_data$A_anc_out,
@@ -739,7 +741,8 @@ create_artattend_Amat <- function(artnum_df, age_groups, sexes, area_aggregation
                       artdat_age_start = age_group_start,
                       artdat_age_end = age_group_start + age_group_span
                     ),
-             by = "artdat_age_group"
+             by = "artdat_age_group",
+             relationship = "many-to-many"
            ) %>%
     ## Note: this would be much faster with tree data structure for age rather than crossing...
     tidyr::crossing(

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -768,7 +768,8 @@ create_artattend_Amat <- function(artnum_df, age_groups, sexes, area_aggregation
     dplyr::left_join(
       area_aggregation,
       by = c("attend_area_id" = "area_id"),
-      multiple = "all"
+      multiple = "all",
+      relationship = "many-to-many"
     ) %>%
     dplyr::mutate(attend_area_id = model_area_id,
                   model_area_id = NULL)

--- a/R/tmb-model.R
+++ b/R/tmb-model.R
@@ -759,7 +759,8 @@ create_artattend_Amat <- function(artnum_df, age_groups, sexes, area_aggregation
                         stringsAsFactors = FALSE) %>%
              dplyr::filter(sex %in% sexes),
              by = "artdat_sex",
-             multiple = "all"
+             multiple = "all",
+             relationship = "many-to-many"
     )
 
   ## Map artattend_area_id to model_area_id

--- a/docker/build
+++ b/docker/build
@@ -4,7 +4,6 @@ HERE=$(dirname $0)
 . $HERE/common
 
 docker build --pull \
-       --no-cache \
        --build-arg GIT_SHA=$GIT_SHA \
        --build-arg GIT_BRANCH=$GIT_BRANCH \
        --build-arg NAOMI_VERSION=$PACKAGE_VERSION \

--- a/docker/build
+++ b/docker/build
@@ -4,6 +4,7 @@ HERE=$(dirname $0)
 . $HERE/common
 
 docker build --pull \
+       --no-cache \
        --build-arg GIT_SHA=$GIT_SHA \
        --build-arg GIT_BRANCH=$GIT_BRANCH \
        --build-arg NAOMI_VERSION=$PACKAGE_VERSION \

--- a/tests/testthat/test-01-run-model.R
+++ b/tests/testthat/test-01-run-model.R
@@ -79,8 +79,7 @@ test_that("model fit without survey ART and survey recency data", {
   options$include_art_t2 = "false"
   options$artattend <- "false"
   expect_error(hintr_run_model(a_hintr_data, options), NA)
-}
-)
+})
 
 test_that("progress messages are printed", {
   skip_on_covr()

--- a/tests/testthat/test-01-run-model.R
+++ b/tests/testthat/test-01-run-model.R
@@ -307,7 +307,7 @@ test_that("model run can be calibrated", {
   ## Output has been calibrated
   expect_true(!is.null(calibrated_output$plot_data_path))
   calibrated_output_obj <- read_hintr_output(calibrated_output$model_output_path)
-  
+
   ## Total population outputs:
   ## * 33 age groups
   ## * 3 sexes
@@ -323,9 +323,9 @@ test_that("model run can be calibrated", {
   ## 12 = number of ANC age groups
   expect_equal(nrow(calibrated_output_obj$output_package$indicators),
                33 * 3 * 9 * (3 * 16 + 1 * 5 + 1 * 4) + 3 * 9 * 9 * 12)
-  
+
   ## Plot data output: T3 and T4 indicators not included -> fewer rows
-  plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)  
+  plot_data_output <- read_hintr_output(calibrated_output$plot_data_path)
   expect_equal(nrow(plot_data_output),
                33 * 3 * 9 * (3 * 16 + 0 * 5 + 0 * 4) + 3 * 9 * 9 * 12)
 
@@ -689,3 +689,39 @@ test_that("trying to calibrate incompatible model output returns error", {
                "Model output out of date please re-run model and try again.")
 })
 
+test_that("calibration plot data can be saved as duckdb database", {
+
+  ## Calibration makes no modification of existing files.
+  output_hash <- tools::md5sum(a_hintr_output$model_output_path)
+  expect_null(a_hintr_output$plot_data_path)
+
+  plot_data_path <- tempfile(fileext = ".duckdb")
+  calibration_output_path <- tempfile(fileext = ".qs")
+  calibrated_output <- hintr_calibrate(a_hintr_output,
+                                       a_hintr_calibration_options,
+                                       plot_data_path,
+                                       calibration_output_path)
+
+  expect_s3_class(calibrated_output, "hintr_output")
+  expect_equal(calibrated_output$plot_data_path, plot_data_path)
+  expect_equal(calibrated_output$model_output_path, calibration_output_path)
+
+  ## Plot data saved as duckdb database
+  data <- read_duckdb(plot_data_path)
+
+  ## Total population outputs:
+  ## * 33 age groups
+  ## * 3 sexes
+  ## * 9 areas
+  ## * 3 output times - 16 indicators
+  ##
+  ## ANC indicators outputs
+  ## 3 = number or output times
+  ## 9 = number of ANC indicators
+  ## 9 = number of areas
+  ## 12 = number of ANC age groups
+
+  ## Plot data output: T3 and T4 indicators not included -> fewer rows
+  expect_equal(nrow(data),
+               33 * 3 * 9 * (3 * 16) + 3 * 9 * 9 * 12)
+})

--- a/tests/testthat/test-hintr-plot-data.R
+++ b/tests/testthat/test-hintr-plot-data.R
@@ -52,3 +52,22 @@ test_that("there is metadata for every indicator in comparison data", {
                            metadata$plot_type == "barchart", ]
   expect_setequal(indicators, comparison$indicator)
 })
+
+test_that("hintr data can be saved and read as qs or duckdb type", {
+  t_qs <- tempfile(fileext = ".qs")
+  t_db <- tempfile(fileext = ".duckdb")
+  d <- data.frame(x = c(1, 2, 3), y = c(4, 5, 6))
+
+  hintr_save(d, t_qs)
+  hintr_save(d, t_db)
+  expect_equal(read_hintr_output(t_qs), read_hintr_output(t_db))
+
+  t <- tempfile(fileext = ".thing")
+  expect_error(hintr_save(d, t),
+               "Cannot save as type 'thing', must be 'qs' or 'duckdb'.")
+
+  x <- list(1, 2, 3)
+  expect_error(hintr_save(x, t_db),
+               paste("Trying to save invalid object as duckdb database.",
+                     "Only data frames can be saved as database."))
+})

--- a/tests/testthat/test-hintr-plot-data.R
+++ b/tests/testthat/test-hintr-plot-data.R
@@ -56,11 +56,18 @@ test_that("there is metadata for every indicator in comparison data", {
 test_that("hintr data can be saved and read as qs or duckdb type", {
   t_qs <- tempfile(fileext = ".qs")
   t_db <- tempfile(fileext = ".duckdb")
+  t_rds <- tempfile(fileext = ".rds")
   d <- data.frame(x = c(1, 2, 3), y = c(4, 5, 6))
 
   hintr_save(d, t_qs)
   hintr_save(d, t_db)
+  ## Can't use hintr_save for rds as we're no longer serialising as rds
+  ## but we could still have historic data saved as rds so we need to
+  ## be able to read it
+  saveRDS(d, t_rds)
+  expect_equal(read_hintr_output(t_rds), d)
   expect_equal(read_hintr_output(t_qs), read_hintr_output(t_db))
+  expect_equal(read_hintr_output(t_rds), read_hintr_output(t_qs))
 
   t <- tempfile(fileext = ".thing")
   expect_error(hintr_save(d, t),
@@ -70,4 +77,8 @@ test_that("hintr data can be saved and read as qs or duckdb type", {
   expect_error(hintr_save(x, t_db),
                paste("Trying to save invalid object as duckdb database.",
                      "Only data frames can be saved as database."))
+
+  expect_error(read_hintr_output(t),
+               paste("Cannot read hintr data of invalid type, got 'thing',",
+                     "must be one of rds, qs or duckdb."))
 })

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -589,7 +589,7 @@ test_that("can generate summary report from zip file", {
 test_that("can generate comparison report with only 1 survey chosen", {
   ## Create a model output with only 1 option chosen for survey_prevalence
   model_output <- a_hintr_output_calibrated$model_output_path
-  output <- qs::qread(model_output)
+  output <- read_hintr_output(model_output)
   options <- yaml::read_yaml(text = output$info$options.yml)
   options$survey_prevalence <- options$survey_prevalence[1]
   output$info$options.yml <- yaml::as.yaml(options)
@@ -681,7 +681,7 @@ test_that("prevalence survey plots not drawn when using aggregate survey", {
 test_that("can generate comparison report with ANC data at T1 not macthed to model T1", {
   ## Create a model output with only 1 option chosen for survey_prevalence
   model_output <- a_hintr_output_calibrated$model_output_path
-  output <- qs::qread(model_output)
+  output <- read_hintr_output(model_output)
   options <- yaml::read_yaml(text = output$info$options.yml)
   options$anc_prevalence_year1 <- "2017"
   options$anc_art_coverage_year1 <- "2017"


### PR DESCRIPTION
This PR will
* Add the ability to save hintr output as a duckdb database, based upon the file extension.

This will be used from hint to slice and read smaller portions of the data so we can deal better with large datasets (like for DRC) 