### PR TITLE
Set T4 and T5 projection quarters when missing from model options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.10
+Version: 2.9.11
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.11
+
+* Automatically set T4 and T5 to 24- and 36-months ahead of T3 if not specified in model options
+
 # naomi 2.9.10
 
 * Update PJNZ extraction for adult ART need Dec 31 for 2023 PJNZ files. Previously child ART was

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.9.11
 
-* Automatically set T4 and T5 to 24- and 36-months ahead of T3 if not specified in model options
+* Automatically set T4 and T5 to 24- and 36-months ahead of T3 if not specified in model options.
 
 # naomi 2.9.10
 

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -328,7 +328,7 @@ naomi_prepare_data <- function(data, options) {
 
   if(is.null(options$calendar_quarter_t5)) {
     # If T5 is not specified, set T4 to 36-months after T3
-    t5 <- calendar_quarter_to_quarter_id(calendar_quarter_t3) + 9
+    t4 <- calendar_quarter_to_quarter_id(calendar_quarter_t4) + 3
     calendar_quarter_t5 <- quarter_id_to_calendar_quarter(t5)
   } else{
     calendar_quarter_t5 <- options$calendar_quarter_t5

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -328,7 +328,7 @@ naomi_prepare_data <- function(data, options) {
 
   if(is.null(options$calendar_quarter_t5)) {
     # If T5 is not specified, set T4 to 36-months after T3
-    t4 <- calendar_quarter_to_quarter_id(calendar_quarter_t4) + 3
+    t5 <- calendar_quarter_to_quarter_id(calendar_quarter_t4) + 3
     calendar_quarter_t5 <- quarter_id_to_calendar_quarter(t5)
   } else{
     calendar_quarter_t5 <- options$calendar_quarter_t5

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -317,8 +317,23 @@ naomi_prepare_data <- function(data, options) {
   calendar_quarter_t1 <- options$calendar_quarter_t1
   calendar_quarter_t2 <- options$calendar_quarter_t2
   calendar_quarter_t3 <- options$calendar_quarter_t3
-  calendar_quarter_t4 <- options$calendar_quarter_t4
-  calendar_quarter_t5 <- options$calendar_quarter_t5
+
+  if(is.null(options$calendar_quarter_t4)) {
+    # If T4 is not specified, set T4 to 24-months after T3
+    t4 <- calendar_quarter_to_quarter_id(calendar_quarter_t3) + 6
+    calendar_quarter_t4 <- quarter_id_to_calendar_quarter(t4)
+  } else{
+    calendar_quarter_t4 <- options$calendar_quarter_t4
+  }
+
+  if(is.null(options$calendar_quarter_t5)) {
+    # If T5 is not specified, set T4 to 36-months after T3
+    t5 <- calendar_quarter_to_quarter_id(calendar_quarter_t3) + 9
+    calendar_quarter_t5 <- quarter_id_to_calendar_quarter(t5)
+  } else{
+    calendar_quarter_t5 <- options$calendar_quarter_t5
+  }
+
   prev_survey_ids  <- options$survey_prevalence
   recent_survey_ids <- options$survey_recently_infected
   artcov_survey_ids <- options$survey_art_coverage
@@ -363,6 +378,8 @@ naomi_prepare_data <- function(data, options) {
   if(!is.null(options$psnu_level)) {
     options$psnu_level <- as.integer(options$psnu_level)
   }
+
+
 
   naomi_mf <- naomi_model_frame(
     area_merged = area_merged,

--- a/tests/testthat/test-02-model-options.R
+++ b/tests/testthat/test-02-model-options.R
@@ -274,3 +274,24 @@ test_that("Option adjust_area_growth handles cases with projection_dur >5 years"
   expect_equal(sum(is.na(naomi_data_longdur$Lproj_t1t2$Lproj_paed)), 0)
   expect_equal(sum(is.na(naomi_data_longdur$Lproj_t1t2$Lproj_incid)), 0)
 })
+
+test_that("Handle backwards regression when T4 and T5 options are missing", {
+
+  a_hintr_data <- format_data_input(a_hintr_data)
+  a_hintr_options <- format_options(a_hintr_options)
+
+  options_old <- a_hintr_options
+
+  # Check that T4 and T5 are 24- and 36-months after T3 when options are not specificed
+  options_old$calendar_quarter_t4 <- NULL
+  options_old$calendar_quarter_t5 <- NULL
+  naomi_data <- naomi_prepare_data(a_hintr_data, options_old)
+
+  t3 <- calendar_quarter_to_quarter_id(naomi_data$model_options$calendar_quarter_t3)
+  t4 <- calendar_quarter_to_quarter_id(naomi_data$model_options$calendar_quarter_t4)
+  t5 <- calendar_quarter_to_quarter_id(naomi_data$model_options$calendar_quarter_t5)
+
+  expect_equal(t4 - t3, 6)
+  expect_equal(t5 - t3, 9)
+
+})


### PR DESCRIPTION
This PR fixes a bug in `naomi_prepare_data()` when reading in regressed model options where T4 and T5 were not specified. 

New behaviour to automatically set T4 and T5 to 24- and 36-months ahead of T3 if they are missing from model options. 