### PR TITLE
Make duckdb connection readonly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.11
+Version: 2.9.12
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.12
+
+* Ensure duckdb connection is readonly
+
 # naomi 2.9.11
 
 * hintr data frame outputs can now be saved as a duckdb database.

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1341,7 +1341,7 @@ read_hintr_output <- function(path) {
 }
 
 read_duckdb <- function(path) {
-  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = path)
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = path, read_only = TRUE)
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   DBI::dbGetQuery(con, sprintf("SELECT * from %s", DUCKDB_OUTPUT_TABLE_NAME))
 }


### PR DESCRIPTION
This should hopefully avoid us creating a lock on the db and mean that we can make concurrent connections