### PR TITLE
fix summary report translation keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.13
+Version: 2.9.14
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# naomi 2.9.14
+
+* Fix scrambled translation keys in summary report.
+
 # naomi 2.9.13
 
-* Ensure duckdb connection is readonly
+* Ensure duckdb connection is readonly.
 
 # naomi 2.9.12
 

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -251,9 +251,9 @@ survey_prev <- paste0(options$survey_prevalence, collapse = ", ")
 survey_art <- paste0(options$survey_art_coverage, collapse = ", ")
 survey_recent <- paste0(options$survey_recently_infected, collapse = ", ")
 
-text <- tibble::tibble(prefix = c(t_("PREVALENCE_SURVEY_PREFIX"), 
-                                  t_("ART_SURVEY_PREFIX"), 
-                                  t_("PREVALENCE_SURVEY_PREFIX")), 
+text <- tibble::tibble(prefix = c(t_("INFECTIONS_SURVEY_PREFIX"), 
+                                  t_("PREVALENCE_SURVEY_PREFIX"), 
+                                  t_("ART_SURVEY_PREFIX")), 
                         source = c(survey_recent,
                                    survey_prev,
                                    survey_art)) %>%


### PR DESCRIPTION
This PR fixes scrambled translation keys that resulted in mislabelling survey data in the summary report.