### PR TITLE
add function to read Spectrum KP table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.14
+Version: 2.9.15
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.9.15
+
+* Extract key population totals from the Spectrum PJNZ file. Data are extracted from 
+  summary table saved in AIM Programme Statistics input for key populations.
+
 # naomi 2.9.14
 
 * Fix scrambled translation keys in summary report.

--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -688,3 +688,60 @@ read_dp <- function(pjnz) {
   dpfile <- grep(".DP$", utils::unzip(pjnz, list = TRUE)$Name, value = TRUE)
   utils::read.csv(unz(pjnz, dpfile), as.is = TRUE)
 }
+
+
+#' Read key population summary data from PJNZ
+#'
+#' Reads key population summary data from Spectrum PJNZ.
+#'
+#' @param pjnz path to PJNZ file
+#'
+#' @examples
+#' pjnz <- system.file("extdata/demo_mwi2019.PJNZ", package = "naomi")
+#' dp <- dp <- naomi:::read_dp(pjnz)
+#' read_dp_keypop_summary(dp)
+#'
+#' @noRd
+#'
+read_dp_keypop_summary <- function(dp) {
+
+  exists_dptag <- function(tag, tagcol = 1) {
+    tag %in% dp[, tagcol]
+  }
+  dpsub <- function(tag, rows, cols, tagcol = 1) {
+    dp[which(dp[, tagcol] == tag) + rows, cols]
+  }
+
+  kp_name <- c("FSW", "MSM", "TG", "PWID")
+
+  if (exists_dptag("<KeyPops MV>")) {
+    kp_tab <- dpsub("<KeyPops MV>", 2:5, 4:7)
+    kp_tab <- sapply(kp_tab, as.numeric)
+  } else {
+    kp_tab <- matrix(NA, 4, 4)
+  }
+
+  if (exists_dptag("<KeyPopsYear MV>")) {
+    kp_year <- as.integer(dpsub("<KeyPopsYear MV>", 2, 4))
+  } else {
+    kp_year <- NA_integer_
+  }
+
+    if (exists_dptag("<KeyPopsFName MV>")) {
+    kp_file <- as.character(dpsub("<KeyPopsFName MV>", 2, 4))
+  } else {
+    kp_file <- NA_character_
+  }
+
+  kp_summary <- data.frame(
+    key_population = kp_name,
+    year = kp_year,
+    population_size = kp_tab[1, ],
+    hiv_prevalence = kp_tab[2, ],
+    art_coverage = kp_tab[3, ],
+    infections = kp_tab[4, ],
+    workbook_file = kp_file
+  )
+
+  kp_summary
+}


### PR DESCRIPTION
This PR adds a function to read the key population summary data saved in the Spectrum Program Statistics tab for key populations. 

It reads the KP data saved in the below Spectrum visualization.  It does not include the "remaining population" bars (which are calculated separately in Spectrum and not saved with the KP workbook summaries).  Those can be calculated from the other Spectrum results read from the PJNZ.


<img width="650" alt="image" src="https://github.com/mrc-ide/naomi/assets/7427899/bacb1def-75a1-4bc2-80e1-342075a123e4">


Here is an example of what the output currently is, using Malawi 2023 Spectrum file as an example:
```
> pjnz <- "~/Downloads/Malawi_2023_National_HIV_estimates_Spectrum_AIM_model.pjnz"
> dp <- naomi:::read_dp(pjnz)
> naomi:::read_dp_keypop_summary(dp)
     key_population year population_size hiv_prevalence art_coverage infections
Data            FSW 2021           39004          0.499        0.910       1460
X               MSM 2021           35391          0.128        0.925        151
X.1              TG 2021            8369          0.270        0.000         72
X.2            PWID 2021            4876          0.138        0.000         21
                       workbook_file
Data MWI_workbook_OS_2022_03_28.xlsx
X    MWI_workbook_OS_2022_03_28.xlsx
X.1  MWI_workbook_OS_2022_03_28.xlsx
X.2  MWI_workbook_OS_2022_03_28.xlsx
```

If no KP workbook was uploaded, the table will return with all `NA` values.

It will be useful to know exactly what is needed for Oli / Katie scaling to figure out what further processing of this will be needed and where to insert in Naomi workflow.