### PR TITLE
Aggregate and tag missing data in data preparation script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.15
+Version: 2.9.16
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# naomi 2.9.16
+
+* Change programme data aggregation scripts to aggreagte and tage missing data. Changes in the outputs of the following functions:
+   - `aggregate_art()` and `aggregate_anc()`:  Data aggregated retaining missing values at lowest admin level and summed totals at higher admin levels.
+   - `prepare_input_time_series_art()` and `prepare_input_time_series_anc()`: New column containing a list of area_ids corresponding to missing districts included in aggreagated totals. 
+
 # naomi 2.9.15
 
 * Add placeholder function `hintr_prepare_agyw_download` for creating AGYW tool.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # naomi 2.9.16
 
-* Change programme data aggregation scripts to aggreagte and tage missing data. Changes in the outputs of the following functions:
+* Change programme data aggregation scripts to aggregate and tag missing data. Changes in the outputs of the following functions:
    - `aggregate_art()` and `aggregate_anc()`:  Data aggregated retaining missing values at lowest admin level and summed totals at higher admin levels.
    - `prepare_input_time_series_art()` and `prepare_input_time_series_anc()`: New column containing a list of area_ids corresponding to missing districts included in aggreagated totals. 
 

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -381,7 +381,7 @@ aggregate_anc <- function(anc, shape) {
       } else {
 
         df <- anc_testing_wide %>%
-          dplyr::group_by(!!col_name := .data[[col_name]], sex, age_group, calendar_quarter) %>%
+          dplyr::group_by(!!col_name := .data[[col_name]], age_group, year) %>%
           dplyr::summarise_at(dplyr::vars(dplyr::all_of(cols_keep)), ~sum(., na.rm = TRUE),
                               .groups = "drop") %>%
           dplyr::rename_with(~gsub("[0-9]$", "", .))

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -400,8 +400,7 @@ aggregate_anc <- function(anc, shape) {
   anc_long <- lapply(anc_dat, aggregate_anc_by_level) %>%
     dplyr::bind_rows() %>%
     dplyr::mutate(time_period = as.character(year), quarter = "Q4", sex = "female",
-                  calendar_quarter = paste0("CY", time_period, quarter),
-                  births_facility = dplyr::if_else(is.na(births_facility), 0, births_facility)) %>%
+                  calendar_quarter = paste0("CY", time_period, quarter)) %>%
     dplyr::left_join(areas %>%
                        dplyr::select(area_id, area_name, area_level,area_level_label,
                                      parent_area_id, area_sort_order),
@@ -450,7 +449,7 @@ prepare_input_time_series_anc <- function(anc, shape) {
       anc_art_among_known = anc_already_art / anc_known_pos,
       anc_art_coverage = anc_already_art / anc_total_pos,
       births_clients_ratio = births_facility / anc_clients
-    ) %>%
+      ) %>%
     dplyr::select(area_id, area_name, area_level, area_level_label, parent_area_id,
                   area_sort_order, age_group,  time_period, year, quarter,
                   calendar_quarter, anc_clients, anc_tested, anc_tested_pos,

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -289,7 +289,7 @@ prepare_input_time_series_art <- function(art, shape) {
     tidyr::pivot_longer(cols = dplyr::starts_with("area_id"), values_to = "area_id") %>%
     # Aggregate missing observations by area_id at all levels
     dplyr::group_by(area_id, plot, calendar_quarter) %>%
-    dplyr::summarise(missing_ids = strsplit(paste0(missing, collapse = ","), split = ","), .groups = "drop")
+    dplyr::summarise(missing_ids = list(missing), .groups = "drop")
 
 
   df_final <- art_plot_data_long %>%
@@ -384,7 +384,7 @@ aggregate_anc <- function(anc, shape) {
           dplyr::group_by(!!col_name := .data[[col_name]], sex, age_group, calendar_quarter) %>%
           dplyr::summarise_at(dplyr::vars(dplyr::all_of(cols_keep)), ~sum(., na.rm = TRUE),
                               .groups = "drop") %>%
-          %>% dplyr::rename_with(~gsub("[0-9]$", "", .))
+          dplyr::rename_with(~gsub("[0-9]$", "", .))
       }
     }
 
@@ -485,7 +485,7 @@ prepare_input_time_series_anc <- function(anc, shape) {
     tidyr::pivot_longer(cols = dplyr::starts_with("area_id"), values_to = "area_id") %>%
     # Aggregate missing observations by area_id at all levels
     dplyr::group_by(area_id, plot, calendar_quarter) %>%
-    dplyr::summarise(missing_ids = strsplit(paste0(missing, collapse = ","), split = ","), .groups = "drop")
+    dplyr::summarise(missing_ids = list(missing), .groups = "drop")
 
   df_final <- anc_plot_data_long %>%
     dplyr::left_join(missing_map, by = dplyr::join_by(area_id, calendar_quarter, plot)) %>%

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -76,10 +76,11 @@ aggregate_art <- function(art, shape) {
       } else {
 
         df <- art_number_wide %>%
-          dplyr::group_by(eval(as.name(col_name)), sex, age_group, calendar_quarter) %>%
+          dplyr::group_by(!!col_name := .data[[col_name]], sex, age_group, calendar_quarter) %>%
           dplyr::summarise_at(dplyr::vars(dplyr::all_of(cols_keep)), ~sum(., na.rm = TRUE),
                               .groups = "drop") %>%
-          dplyr::rename(area_id = `eval(as.name(col_name))`)
+          dplyr::rename_with(~gsub("[0-9]$", "", .))
+
       }
 
     }
@@ -107,7 +108,7 @@ aggregate_art <- function(art, shape) {
                       area_level_label, parent_area_id, area_sort_order),
       by = c("area_id")
     ) %>%
-    dplyr::select(area_id, area_level, area_level_label,parent_area_id,
+    dplyr::select(area_id, area_level, area_name, area_level_label,parent_area_id,
                   area_sort_order, sex, age_group,time_period, year, quarter,
                   calendar_quarter, dplyr::everything()) %>%
     dplyr::arrange(year, area_sort_order)
@@ -380,10 +381,10 @@ aggregate_anc <- function(anc, shape) {
       } else {
 
         df <- anc_testing_wide %>%
-          dplyr::group_by(eval(as.name(col_name)), age_group, year) %>%
+          dplyr::group_by(!!col_name := .data[[col_name]], sex, age_group, calendar_quarter) %>%
           dplyr::summarise_at(dplyr::vars(dplyr::all_of(cols_keep)), ~sum(., na.rm = TRUE),
                               .groups = "drop") %>%
-          dplyr::rename(area_id = `eval(as.name(col_name))`)
+          %>% dplyr::rename_with(~gsub("[0-9]$", "", .))
       }
     }
 


### PR DESCRIPTION
This PR updates the ART and ANC aggregation scripts to aggregate with missing data and tag aggregated totals missing data from specific districts.  

Previous behaviour:
*  `aggregate_art()` and `aggregate_anc()`: Propagate missing data up through higher admin level aggreagteg totals

New behaviour:
*   `aggregate_art()` and `aggregate_anc()`:  Data aggregated retaining missing values at lowest admin level and summed totals at higher admin levels.
* `prepare_input_time_series_art()` and `prepare_input_time_series_anc()`: New column containing a list of area_ids corresponding to missing districts included in aggreagated totals. 