### PR TITLE
Format vmmc output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # naomi 2.9.19
 
-* Add optional `vmmc_path` to spectrum download function
+* Add optional `vmmc_path` to Spectrum download function for path to DMMPT2 output Excel file.
+* Add DMMPT2 outputs to PEPFAR Datapack CSV download, if DMMPT2 output file exists.
 * Silence `spdep v1.2-8` warnings from `mat2listw()` (issue #421).
 
 # naomi 2.9.18

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -20,7 +20,7 @@ get_meta_indicator <- function() {
 
 
 
-add_stats <- function(df, mode = NULL, sample = NULL, prefix = "", na.rm = FALSE){
+add_stats <- function(df, mode = NULL, sample = NULL, prefix = "", na.rm = FALSE) {
 
   v <- df
 
@@ -982,16 +982,18 @@ save_output <- function(filename, dir,
   if (export_datapack) {
 
     if (!is.null(vmmc_path)) {
-      assert_scalar_character(vmmc_path)
       ## Skip the first row, the file has two rows of headers
-      vmmc_datapack <- openxlsx::read.xlsx(vmmc_path, sheet = "Datapack inputs",
-                                           startRow = 2)
-      ## TODO: Add it to relevant place in download
+      vmmc_datapack_raw <- openxlsx::read.xlsx(vmmc_path, sheet = "Datapack inputs",
+                                               startRow = 2)
+      vmmc_datapack <- transform_dmppt2(vmmc_datapack_raw)
+    } else {
+      vmmc_datapack <- NULL
     }
 
     write_datapack_csv(naomi_output = naomi_output,
                        path = PEPFAR_DATAPACK_FILENAME,   # global defined in R/pepfar-datapack.R
-                       psnu_level = naomi_output$fit$model_options$psnu_level)
+                       psnu_level = naomi_output$fit$model_options$psnu_level,
+                       dmppt2_output = vmmc_datapack)
   }
 
 

--- a/R/pepfar-datapack.R
+++ b/R/pepfar-datapack.R
@@ -64,7 +64,8 @@ write_datapack_csv <- function(naomi_output,
 
   
   if (is.null(psnu_level) || !psnu_level %in% naomi_output$meta_area$area_level) {
-    warning("PSNU level ", psnu_level, " not included in model outputs.")
+    naomi_warning(paste0("PSNU level ", psnu_level, " not included in model outputs."),
+                  "download_results")
   }
 
   datapack_indicator_map$calendar_quarter <- naomi_output$meta_period$calendar_quarter[datapack_indicator_map$time]
@@ -100,8 +101,6 @@ write_datapack_csv <- function(naomi_output,
   ## Append VMMC indicators from DMPPT2 output to Naomi indicators
   if(!is.null(dmppt2_output)) {
 
-    ## TO DO: add check for area_id
-    
     dmppt2_output <- dmppt2_output %>%
       dplyr::left_join(
         dplyr::select(datapack_indicator_map, indicator, calendar_quarter),
@@ -109,7 +108,7 @@ write_datapack_csv <- function(naomi_output,
       ) %>%
       dplyr::rename(mean = value) %>%
       dplyr::mutate(se = 0.0)
-
+    
     indicators <- dplyr::bind_rows(indicators, dmppt2_output)
   }
   

--- a/R/pepfar-datapack.R
+++ b/R/pepfar-datapack.R
@@ -64,8 +64,7 @@ write_datapack_csv <- function(naomi_output,
 
   
   if (is.null(psnu_level) || !psnu_level %in% naomi_output$meta_area$area_level) {
-    naomi_warning(paste0("PSNU level ", psnu_level, " not included in model outputs."),
-                  "download_results")
+    warning("PSNU level ", psnu_level, " not included in model outputs.")
   }
 
   datapack_indicator_map$calendar_quarter <- naomi_output$meta_period$calendar_quarter[datapack_indicator_map$time]

--- a/R/pepfar-datapack.R
+++ b/R/pepfar-datapack.R
@@ -7,6 +7,8 @@ PEPFAR_DATAPACK_FILENAME <- "pepfar_datapack_indicators_2024.csv"
 #' @param psnu_level area_level for PEPFAR PSNU to export. If NULL,
 #'    first looks in lookup table for the correct area_level, and
 #'    if not defaults to the highest level of the area hierarchy.
+#' @param dmppt2_output data frame containing the _Datapack inputs_
+#'    sheet of DMPPT2 output file.
 #'
 #' @details
 #'
@@ -26,7 +28,8 @@ PEPFAR_DATAPACK_FILENAME <- "pepfar_datapack_indicators_2024.csv"
 #' @export
 write_datapack_csv <- function(naomi_output,
                                path,
-                               psnu_level = NULL) {
+                               psnu_level = NULL,
+                               dmppt2_output = NULL) {
 
   stopifnot(inherits(naomi_output, "naomi_output"))
 
@@ -49,15 +52,19 @@ write_datapack_csv <- function(naomi_output,
     }
   }
 
-  if (is.null(psnu_level) || !psnu_level %in% naomi_output$meta_area$area_level) {
+  ## If using the demo data, don't print this warning.
+  ## The demo data only contain levels 0:2, but have ISO3 = "MWI", for which psnu_level = 3.
+  ## A better way to handle this is to change the ISO3 for the demo data to an artificial
+  ## code. However, some hint validation needs to be relaxed to enable this.
+  is_demo_data <- "MWI_2_5_demo" %in% naomi_output$meta_area$area_id &&
+    setequal(0:2, naomi_output$meta_area$area_level)
+  if(is_demo_data) {
+    psnu_level <- 2L
+  }
 
-    ## If using the demo data, don't print this warning.
-    ## The demo data only contain levels 0:2, but have ISO3 = "MWI", for which psnu_level = 3.
-    ## A better way to handle this is to change the ISO3 for the demo data to an artificial
-    ## code. However, some hint validation needs to be relaxed to enable this.
-    if (!("MWI_2_5_demo" %in% naomi_output$meta_area$area_id && setequal(0:2, naomi_output$meta_area$area_level))) {
-      warning("PSNU level ", psnu_level, " not included in model outputs.")
-    }
+  
+  if (is.null(psnu_level) || !psnu_level %in% naomi_output$meta_area$area_level) {
+    warning("PSNU level ", psnu_level, " not included in model outputs.")
   }
 
   datapack_indicator_map$calendar_quarter <- naomi_output$meta_period$calendar_quarter[datapack_indicator_map$time]
@@ -90,6 +97,22 @@ write_datapack_csv <- function(naomi_output,
 
   indicators <- datapack_aggregate_1to9(naomi_output$indicators)
 
+  ## Append VMMC indicators from DMPPT2 output to Naomi indicators
+  if(!is.null(dmppt2_output)) {
+
+    ## TO DO: add check for area_id
+    
+    dmppt2_output <- dmppt2_output %>%
+      dplyr::left_join(
+        dplyr::select(datapack_indicator_map, indicator, calendar_quarter),
+        by = "indicator"
+      ) %>%
+      dplyr::rename(mean = value) %>%
+      dplyr::mutate(se = 0.0)
+
+    indicators <- dplyr::bind_rows(indicators, dmppt2_output)
+  }
+  
   dat <- indicators %>%
     dplyr::rename(sex_naomi = sex) %>%
     dplyr::semi_join(
@@ -105,7 +128,7 @@ write_datapack_csv <- function(naomi_output,
     dplyr::semi_join(
       datapack_indicator_map,
       by = c("indicator", "calendar_quarter")
-    )  %>%
+    ) %>%
     dplyr::filter(
     (sex_naomi %in% datapack_sex_map$sex_naomi &
        age_group %in% datapack_age_group_map$age_group |
@@ -138,6 +161,10 @@ write_datapack_csv <- function(naomi_output,
       by = "area_id"
     ) %>%
     dplyr::arrange(calendar_quarter, indicator_sort_order, area_id, sex_naomi, age_group)
+
+
+  dat$district_rse[is.na(dat$district_rse) & dat$indicator %in% c("circ_new", "circ_ever")] <- 0.0
+    
 
   ## Merge data pack Ids
   dat <- dplyr::left_join(dat, strat,
@@ -236,4 +263,29 @@ datapack_aggregate_1to9 <- function(indicators) {
 
   indicators[names(indicators1to9)] %>%
     dplyr::bind_rows(indicators1to9)
+}
+
+transform_dmppt2 <- function(x) {
+
+  if(any(names(x)[3:11] != c("area_id", "15-24", "25-34", "35-49", "50+",
+                             "15-24", "25-34", "35-49", "50+"))) {
+    stop("DMMPT2 output file does not have expected column names.")
+  }
+
+  names(x)[4:7] <- paste0("circ_new:", names(x)[4:7])
+  names(x)[8:11] <- paste0("circ_ever:", names(x)[8:11])
+
+  xl <- x %>%
+    tidyr::pivot_longer(cols = 4:11, names_sep = ":", names_to = c("indicator", "age")) %>%
+    dplyr::mutate(
+      sex = "male",
+      age_group = dplyr::recode(age,
+                                "15-24" = "Y015_024",
+                                "25-34" = "Y025_034",
+                                "35-49" = "Y035_049",
+                                "50+" = "Y050_999")
+    ) %>%
+    dplyr::select(area_id, sex, age_group, indicator, value)
+
+  xl
 }

--- a/inst/datapack/datapack_indicator_mapping.csv
+++ b/inst/datapack/datapack_indicator_mapping.csv
@@ -25,3 +25,5 @@ plhiv_attend,PLHIV_Attend.T,PLHIV_Attend.T,,TRUE,4
 infections,NEW_INFECTIONS_SUBNAT.T2,NEW_INFECTIONS_SUBNAT.T2,,TRUE,5
 plhiv,PLHIV_Residents.T2,PLHIV_Residents.T2,,TRUE,5
 plhiv_attend,PLHIV_Attend.T2,PLHIV_Attend.T2,,TRUE,5
+circ_ever,ZayJeEa6pCa,VMMC_TOTALCIRC_SUBNAT.T_1,,TRUE,3
+circ_new,SSun4i7nHlV,VMMC_CIRC_SUBNAT.T_1,,TRUE,3

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -89,8 +89,11 @@ test_that("spectrum download can include vmmc data", {
   t <- tempfile()
   unzip(out$path, PEPFAR_DATAPACK_FILENAME, exdir = t)
   datapack <- utils::read.csv(file.path(t, PEPFAR_DATAPACK_FILENAME))
-  # TODO: Expand the checks here
+
   expect_true("psnu_uid" %in% colnames(datapack))
+  expect_true(!any(is.na(datapack)))
+  expect_true(all(c("VMMC_CIRC_SUBNAT.T_1", "VMMC_TOTALCIRC_SUBNAT.T_1") %in%
+                    datapack$indicator_code))
 
   unzip(out$path, "notes.txt", exdir = t)
   saved_notes <- readLines(file.path(t, "notes.txt"))

--- a/tests/testthat/test-pepfar-datapack.R
+++ b/tests/testthat/test-pepfar-datapack.R
@@ -29,7 +29,8 @@ test_that("datapack_indicator_map is well formed", {
   datapack_indicator_map <- naomi_read_csv(system_file("datapack", "datapack_indicator_mapping.csv"))
   expect_true(all(c("indicator", "datapack_indicator_code", "is_integer", "time") %in%
                   names(datapack_indicator_map)))
-  expect_true(all(datapack_indicator_map$indicator %in% get_meta_indicator()$indicator))
+  expect_true(all(datapack_indicator_map$indicator %in%
+                    c(get_meta_indicator()$indicator, "circ_ever", "circ_new")))
   expect_equal(anyDuplicated(datapack_indicator_map[c("indicator", "time")]), 0)
   expect_equal(anyDuplicated(datapack_indicator_map$datapack_indicator_code), 0)
 })

--- a/tests/testthat/test-pepfar-datapack.R
+++ b/tests/testthat/test-pepfar-datapack.R
@@ -69,3 +69,18 @@ test_that("datapack export writes correct psnu_level", {
   expect_true(!any(is.na(datapack1)))
   expect_match(datapack3$area_id, "^MWI_3_")
 })
+
+test_that("datapack export includes DMMPT2 VMMC data", {
+
+  vmmc_path <- file.path("testdata", "vmmc.xlsx")
+  vmmc_datapack_raw <- openxlsx::read.xlsx(vmmc_path, sheet = "Datapack inputs", startRow = 2)
+  vmmc_datapack <- transform_dmppt2(vmmc_datapack_raw)
+
+  tmpf <- tempfile(fileext = ".csv")
+  res <- write_datapack_csv(a_output_full, tmpf, dmppt2_output = vmmc_datapack)
+
+  datapack1 <- readr_read_csv(res)
+  expect_true(!any(is.na(datapack1)))
+  expect_true(all(c("VMMC_CIRC_SUBNAT.T_1", "VMMC_TOTALCIRC_SUBNAT.T_1") %in%
+                    datapack1$indicator_code))
+})


### PR DESCRIPTION
This PR formats the DMMPT2 output and appends it to the PEPFAR Datapack CSV if 

It builds on #418. I have made a separate PR in case you want to merge that one immediately before reviewing this, but they can be combined and merged together.

This code does _not_ check that the DMMPT2 file `area_id` are consistent with the Naomi fit.  What do we want to test there, and how do we want it to fail (error vs. warning)?

Options for what to check:

1. All DMPPT2 `area_id` are contained in the Naomi fit `area_id`
2. All Naomi fit `area_id` are contained in the DMPPT2 output (we don't want this option)
3. All Naomi fit `area_id` at the PSNU level are contained in the DMMPT2 output file

I think we want option 3.

I'm not sure how it should fail:
* A hard error could be a nuisance as it stops them from downloading Naomi zip altogether. 
* But a warning likely to be glossed over and produce a Datapack CSV that is missing some rows for the circumcision outputs

One option would be to write the Naomi zip file, but omit the PEPFAR CSV if there is an issue with the DMMPT2 file. (Still could be slightly annoying, but less so than error writing the Naomi zip altogether).