### PR TITLE
Use workaround to avoid duckdb raising unnecessary warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.9.24
+Version: 2.9.25
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.9.25
+
+* Suppress warning raised from duckdb shutdown
+
 # naomi 2.9.24
 
 * Migrate to github actions

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1355,7 +1355,7 @@ read_hintr_output <- function(path) {
 }
 
 read_duckdb <- function(path) {
-  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = path, read_only = TRUE)
+  con <- DBI::dbConnect(duckdb::duckdb(dbdir = path, read_only = TRUE))
   on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
   DBI::dbGetQuery(con, sprintf("SELECT * from %s", DUCKDB_OUTPUT_TABLE_NAME))
 }

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -149,9 +149,9 @@ hintr_save <- function(obj, file) {
       stop(paste("Trying to save invalid object as duckdb database.",
               "Only data frames can be saved as database."))
     }
-    con <- DBI::dbConnect(duckdb::duckdb(), dbdir = file)
+    con <- DBI::dbConnect(duckdb::duckdb(dbdir = file))
+    on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
     DBI::dbWriteTable(con, DUCKDB_OUTPUT_TABLE_NAME, obj)
-    DBI::dbDisconnect(con, shutdown = TRUE)
   } else {
     stop(sprintf("Cannot save as type '%s', must be 'qs' or 'duckdb'.", type))
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Naomi <img src='images/naomi_hex.png' align="right" height="139" />
 
-![R CMD check](https://github.com/mrc-ide/naomi/actions/workflows/R-CMD-check.yml/badge.svg)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![R-CMD-check](https://github.com/mrc-ide/naomi/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mrc-ide/naomi/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/mrc-ide/naomi/branch/master/graph/badge.svg)](https://codecov.io/gh/mrc-ide/naomi?branch=master)
 
 Naomi model for subnational HIV estimates

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,8 @@ ENV NAOMI_GIT_BRANCH $GIT_BRANCH
 ENV NAOMI_VERSION $NAOMI_VERSION
 
 RUN install_packages --repo=https://mrc-ide.r-universe.dev \
-    mockr \
     rvest \
-    pkgbuild \
-    testthat.buildkite
+    pkgbuild
 
 ## Model run will try to parallelise over as many threads as are available
 ## potentially slowing the application, manually limit threads to 1


### PR DESCRIPTION
After closing a db connection to duckdb when garbage collection runs we're seeing a warning raised about using `shutdown = TRUE`. We are setting this flag, but the warning is still being raised. We can work around this see https://github.com/duckdb/duckdb-r/issues/60