### PR TITLE
Replace utils read with readr read function

### DIFF
--- a/R/inputs-spectrum.R
+++ b/R/inputs-spectrum.R
@@ -185,7 +185,7 @@ read_dp_art_dec31 <- function(dp) {
 
   ## In Spectrum 2023, "<NeedARTDec31 MV>" was updated to include children in the totals
   ## -> now need to sum over 5-year age groups for age 15+ to get the adult ART need
-  
+
   male_15plus_needart <- dpsub("<NeedARTDec31 MV>", 4:17*3 + 3, timedat.idx)
   male_15plus_needart <- vapply(lapply(male_15plus_needart, as.numeric), sum, numeric(1))
 
@@ -195,14 +195,14 @@ read_dp_art_dec31 <- function(dp) {
   art15plus_need <- rbind(male_15plus_needart, female_15plus_needart)
   dimnames(art15plus_need) <- list(sex = c("male", "female"), year = proj.years)
 
-  
+
   if (any(art15plus_num[art15plus_isperc == 1] < 0 |
           art15plus_num[art15plus_isperc == 1] > 100)) {
     stop("Invalid percentage on ART entered for adult ART")
   }
 
   ## # Adult on ART adjustment factor
-  ## 
+  ##
   ## * Implemented from around Spectrum 6.2 (a few versions before)
   ## * Allows user to specify scalar to reduce number on ART in each year ("<AdultARTAdjFactor>")
   ## * Enabled / disabled by checkbox flag ("<AdultARTAdjFactorFlag>")
@@ -281,7 +281,7 @@ read_dp_art_dec31 <- function(dp) {
   names(child_art) <- proj.years
 
   ## # Child on ART adjustment factor
-  ## 
+  ##
   ## * Implemented same as adult adjustment factor above
 
   if (exists_dptag("<ChildARTAdjFactorFlag>") &&
@@ -686,5 +686,8 @@ extract_eppasm_pregprev <- function(mod, fp, years = NULL) {
 
 read_dp <- function(pjnz) {
   dpfile <- grep(".DP$", utils::unzip(pjnz, list = TRUE)$Name, value = TRUE)
-  utils::read.csv(unz(pjnz, dpfile), as.is = TRUE)
+  as.data.frame(
+    readr::read_csv(unz(pjnz, dpfile),
+                    name_repair = "minimal",
+                    col_types = readr::cols(.default = "c")))
 }


### PR DESCRIPTION
Was just having a quick look at `anc_spectrum_warning` and `art_spectrum_warning` as we will use similar code to build the data for the new input plots. The majority of the time running these functions is just reading the spectrum files. Particularly for large countries. I've replaced the reading with utils::read.csv with readr as it is quite a bit faster.

For DRC, read_dp is the function before this change, read_dp2 is the function after this change. Note the only difference should be is that where `read_dp` would return columns with the types set by R. They are always "character" now. I believe this is fine because we have to manually convert any data later anyway (see e.g. `read_dp_art_dec31`) as the type interpretation is often broken due to how DP files are stored in disk.

```
bench::mark(read_dp(data$pjnz), read_dp2(data$pjnz), check = FALSE, iterations = 5)
# A tibble: 3 × 13
  expression             min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory     time       gc      
  <bch:expr>           <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>     <list>     <list>  
1 read_dp(data$pjnz)   313ms  341ms      2.44    75.5MB     1.95     5     4      2.05s <NULL> <Rprofmem> <bench_tm> <tibble>
2 read_dp2(data$pjnz)  176ms  188ms      5.31    24.1MB     1.06     5     1   941.76ms <NULL> <Rprofmem> <bench_tm> <tibble>
```