### PR TITLE
Remove installs from github where packages have been updated in R universe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,9 +77,6 @@ LinkingTo:
     RcppEigen,
     TMB
 Remotes:
-    bergant/datamodelr,
-    mrc-ide/naomi.options,
-    eppasm=github::mrc-ide/eppasm,
-    first90=github::mrc-ide/first90release
+    bergant/datamodelr
 Config/testthat/edition: 3
 Config/testthat/parallel: true


### PR DESCRIPTION
We had these pinned to force installation from github as the ones in the naomi.base image were out of date (because it had stopped building properly) I have fixed naomi.base image so it is up to date and we can remove these in favour of installing them via r-universe