### PR TITLE
Fix build failures on R devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,10 +48,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ matrix.config.r == 'devel' }}
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,10 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ matrix.config.r == 'devel' }}
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -96,28 +96,28 @@ get_art_metadata <- function(art) {
 get_aggregate_exprs <- function() {
   summary_exprs <- rlang::exprs(
     # ART
-    art_total = sum(art_current,  na.rm = na_rm),
-    art_adult = sum(art_current * as.integer(age_group == "Y015_999"),  na.rm = na_rm),
-    art_adult_f = sum(art_current * as.integer(sex == "female" & age_group == "Y015_999"),  na.rm = na_rm),
-    art_adult_m = sum(art_current * as.integer(sex == "male" & age_group == "Y015_999"),  na.rm = na_rm),
-    art_child = sum(art_current * as.integer(age_group == "Y000_014"),  na.rm = na_rm),
+    art_total = sum(art_current,  na.rm = na_rm[[1]]),
+    art_adult = sum(art_current * as.integer(age_group == "Y015_999"),  na.rm = na_rm[[1]]),
+    art_adult_f = sum(art_current * as.integer(sex == "female" & age_group == "Y015_999"),  na.rm = na_rm[[1]]),
+    art_adult_m = sum(art_current * as.integer(sex == "male" & age_group == "Y015_999"),  na.rm = na_rm[[1]]),
+    art_child = sum(art_current * as.integer(age_group == "Y000_014"),  na.rm = na_rm[[1]]),
 
-    art_new_total = sum(art_new, na.rm = na_rm),
-    art_new_adult = sum(art_new * as.integer(age_group == "Y015_999"), na.rm = na_rm),
-    art_new_adult_f = sum(art_new * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm),
-    art_new_adult_m = sum(art_new * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm),
-    art_new_child = sum(art_new * as.integer(age_group == "Y000_014"), na.rm = na_rm),
+    art_new_total = sum(art_new, na.rm = na_rm[[1]]),
+    art_new_adult = sum(art_new * as.integer(age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    art_new_adult_f = sum(art_new * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    art_new_adult_m = sum(art_new * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    art_new_child = sum(art_new * as.integer(age_group == "Y000_014"), na.rm = na_rm[[1]]),
 
-    vl_tested_12mos_total = sum(vl_tested_12mos, na.rm = na_rm),
-    vl_tested_12mos_adult = sum(vl_tested_12mos * as.integer(age_group == "Y015_999"), na.rm = na_rm),
-    vl_tested_12mos_adult_f = sum(vl_tested_12mos * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm),
-    vl_tested_12mos_adult_m = sum(vl_tested_12mos * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm),
-    vl_tested_12mos_child = sum(vl_tested_12mos * as.integer(age_group == "Y000_014"), na.rm = na_rm),
-    vl_suppressed_12mos_total = sum(vl_suppressed_12mos, na.rm = na_rm),
-    vl_suppressed_12mos_adult = sum(vl_suppressed_12mos * as.integer(age_group == "Y015_999"), na.rm = na_rm),
-    vl_suppressed_12mos_adult_f = sum(vl_suppressed_12mos * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm),
-    vl_suppressed_12mos_adult_m = sum(vl_suppressed_12mos * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm),
-    vl_suppressed_12mos_child = sum(vl_suppressed_12mos * as.integer(age_group == "Y000_014"), na.rm = na_rm)
+    vl_tested_12mos_total = sum(vl_tested_12mos, na.rm = na_rm[[1]]),
+    vl_tested_12mos_adult = sum(vl_tested_12mos * as.integer(age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_tested_12mos_adult_f = sum(vl_tested_12mos * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_tested_12mos_adult_m = sum(vl_tested_12mos * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_tested_12mos_child = sum(vl_tested_12mos * as.integer(age_group == "Y000_014"), na.rm = na_rm[[1]]),
+    vl_suppressed_12mos_total = sum(vl_suppressed_12mos, na.rm = na_rm[[1]]),
+    vl_suppressed_12mos_adult = sum(vl_suppressed_12mos * as.integer(age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_suppressed_12mos_adult_f = sum(vl_suppressed_12mos * as.integer(sex == "female" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_suppressed_12mos_adult_m = sum(vl_suppressed_12mos * as.integer(sex == "male" & age_group == "Y015_999"), na.rm = na_rm[[1]]),
+    vl_suppressed_12mos_child = sum(vl_suppressed_12mos * as.integer(age_group == "Y000_014"), na.rm = na_rm[[1]])
   )
 
   mutate_exprs <- rlang::exprs(


### PR DESCRIPTION
`sum` function has changed in R devel to error if passed with a vector of `na.rm` so this is now erroring.

Previously `sum(c(1, 2), na.rm = c(TRUE, FALSE))` would just use the first. I've updated this to just use the first explicitly as they should all be the same