### PR TITLE
Replace qs with qs2, make qs a suggested dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.10.16
+Version: 2.10.17
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 Additional_repositories:
     https://mrc-ide.r-universe.dev,
     https://duckdb.r-universe.dev
@@ -39,7 +39,7 @@ Imports:
     openxlsx,
     plotly,
     prettyunits,
-    qs,
+    qs2,
     readr (>= 2.0.1),
     rlang,
     rmarkdown,
@@ -65,6 +65,7 @@ Suggests:
     lubridate,
     mockery,
     mockr,
+    qs,
     readxl,
     rvest,
     scales,
@@ -77,7 +78,7 @@ LinkingTo:
     RcppEigen,
     TMB
 Remotes:
-    qsbase/qs,
-    bergant/datamodelr
+    bergant/datamodelr,
+    qsbase/qs
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,6 +77,7 @@ LinkingTo:
     RcppEigen,
     TMB
 Remotes:
+    qsbase/qs,
     bergant/datamodelr
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# naomi 2.10.17
+
+* Use 'qs2' for saving new files, 'qs' package has been deprecated. Make 'qs' an optional dependency for backwards compatibility.
+
 # naomi 2.10.16
 
-* Make ANC labels for prevalence and ART coverage consistent between time series and choropleth
+* Make ANC labels for prevalence and ART coverage consistent between time series and choropleth.
 
 # naomi 2.10.15
 

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1355,7 +1355,10 @@ get_period_metadata <- function(calendar_quarters) {
 #' @export
 read_hintr_output <- function(path) {
   type <- tolower(tools::file_ext(path))
-  if (type == "qs") {
+  if (type == "qs2") {
+    qs2::qs_read(path)
+  } else if (type == "qs") {
+    assert_package_installed("qs")
     qs::qread(path)
   } else if (type == "duckdb") {
     read_duckdb(path)
@@ -1364,7 +1367,7 @@ read_hintr_output <- function(path) {
     readRDS(path)
   } else {
     stop(sprintf(paste("Cannot read hintr data of invalid type, got '%s',",
-                       "must be one of rds, qs or duckdb."), type))
+                       "must be one of rds, qs2, qs or duckdb."), type))
   }
 }
 

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -1,7 +1,7 @@
 #' Run the model and save output
 #'
 #' This prepares the model inputs from data and options and saves output as
-#' a qs file.
+#' a qs2 file.
 #'
 #' @param data List of paths to input data files.
 #' @param options List of model run options (see details).
@@ -50,7 +50,7 @@
 #' @export
 #'
 hintr_run_model <- function(data, options,
-                            model_output_path = tempfile(fileext = ".qs"),
+                            model_output_path = tempfile(fileext = ".qs2"),
                             validate = TRUE) {
   model_run_output <- handle_naomi_warnings(
     run_model(data, options, validate))
@@ -149,7 +149,10 @@ DUCKDB_OUTPUT_TABLE_NAME <- "data"
 
 hintr_save <- function(obj, file) {
   type <- tolower(tools::file_ext(file))
-  if (type == "qs") {
+  if (type == "qs2") {
+    qs2::qs_save(obj, file)
+  } else if (type == "qs") {
+    assert_package_installed("qs")
     qs::qsave(obj, file, preset = "fast")
   } else if (type == "duckdb") {
     if (!is.data.frame(obj)) {
@@ -161,7 +164,8 @@ hintr_save <- function(obj, file) {
     on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
     DBI::dbWriteTable(con, DUCKDB_OUTPUT_TABLE_NAME, obj)
   } else {
-    stop(sprintf("Cannot save as type '%s', must be 'qs' or 'duckdb'.", type))
+    stop(sprintf("Cannot save as type '%s', must be 'qs2', 'qs' or 'duckdb'.",
+                 type))
   }
 }
 
@@ -188,8 +192,8 @@ assert_model_output_version <- function(obj, version = NULL) {
 #' @return Calibrated hintr_output object
 #' @export
 hintr_calibrate <- function(
-  output, calibration_options, plot_data_path = tempfile(fileext = ".qs"),
-  calibrate_output_path = tempfile(fileext = ".qs")) {
+  output, calibration_options, plot_data_path = tempfile(fileext = ".qs2"),
+  calibrate_output_path = tempfile(fileext = ".qs2")) {
   out <- handle_naomi_warnings(run_calibrate(output, calibration_options))
   warnings <- out$warnings
   out$calibrate_data$warnings$calibrate <- warnings

--- a/R/tmb-model-r-implementation.R
+++ b/R/tmb-model-r-implementation.R
@@ -852,7 +852,7 @@ naomi_objective_function_r <- function(d, p) {
 #' @param u vector of spatial component of random effect.
 #' @param sigma marginal standard deviation (>0).
 #' @param phi proportion of marginal variance explained by spatial structured
-#'            component u (phi \in [0, 1]).
+#'            component u (phi \in \[0, 1\]).
 #' @param Q scaled structure matrix for spatial component.
 #'
 #' @return Log probability density of x and u.

--- a/inst/report/comparison_report.Rmd
+++ b/inst/report/comparison_report.Rmd
@@ -37,7 +37,7 @@ options(scipen=10000000)
 outputs <- params$outputs
 
 # Read files if hintr rds provided
-if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs")) {
+if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs", "qs2")) {
 
   model_object <- read_hintr_output(outputs)
   outputs <- model_object$output_package

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -39,7 +39,7 @@ title: `r title`
 options(scipen=10000000)
 
 # Read files if hintr rds provided
-if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs")) {
+if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs", "qs2")) {
   
   model_object <- read_hintr_output(params$outputs)
   outputs <- model_object$output_package

--- a/man/hintr_calibrate.Rd
+++ b/man/hintr_calibrate.Rd
@@ -7,8 +7,8 @@
 hintr_calibrate(
   output,
   calibration_options,
-  plot_data_path = tempfile(fileext = ".qs"),
-  calibrate_output_path = tempfile(fileext = ".qs")
+  plot_data_path = tempfile(fileext = ".qs2"),
+  calibrate_output_path = tempfile(fileext = ".qs2")
 )
 }
 \arguments{

--- a/man/hintr_run_model.Rd
+++ b/man/hintr_run_model.Rd
@@ -7,7 +7,7 @@
 hintr_run_model(
   data,
   options,
-  model_output_path = tempfile(fileext = ".qs"),
+  model_output_path = tempfile(fileext = ".qs2"),
   validate = TRUE
 )
 }
@@ -26,7 +26,7 @@ Paths to output files
 }
 \description{
 This prepares the model inputs from data and options and saves output as
-a qs file.
+a qs2 file.
 }
 \details{
 The \code{data} argument must be a list specifying paths to the following:

--- a/man/naomi_model_frame.Rd
+++ b/man/naomi_model_frame.Rd
@@ -14,7 +14,6 @@ naomi_model_frame(
   calendar_quarter2,
   calendar_quarter3,
   calendar_quarter4 = "CY2024Q3",
-  calendar_quarter5 = "CY2025Q3",
   age_groups = get_five_year_age_groups(),
   sexes = c("male", "female"),
   omega = 0.7,
@@ -55,8 +54,6 @@ ids.}
 \item{calendar_quarter3}{Calendar quarter at time 3 ("CYyyyyQq")}
 
 \item{calendar_quarter4}{Calendar quarter at time 4 ("CYyyyyQq")}
-
-\item{calendar_quarter5}{Calendar quarter at time 5 ("CYyyyyQq")}
 
 \item{age_groups}{Age groups to include in model frame}
 

--- a/man/prepare_input_time_series_art.Rd
+++ b/man/prepare_input_time_series_art.Rd
@@ -4,7 +4,7 @@
 \alias{prepare_input_time_series_art}
 \title{Prepare data for ART input time series plots}
 \usage{
-prepare_input_time_series_art(art, shape)
+prepare_input_time_series_art(art, shape, pjnz)
 }
 \arguments{
 \item{art}{Path to file containing ART data or ART data object}

--- a/tests/testthat/test-01-run-model.R
+++ b/tests/testthat/test-01-run-model.R
@@ -1,5 +1,5 @@
 test_that("model can be run", {
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   model_run <- hintr_run_model(a_hintr_data,
                                a_hintr_options,
                                output_path)
@@ -43,7 +43,7 @@ test_that("model can be run without programme data", {
   options$artattend_t2 <- NULL
   options$artattend_log_gamma_offset <- NULL
 
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   model_run <- hintr_run_model(data, options, output_path)
   expect_equal(names(model_run),
                c("plot_data_path", "model_output_path", "version", "warnings"))
@@ -81,7 +81,7 @@ test_that("model fit without survey ART and survey recency data", {
 
 test_that("progress messages are printed", {
   skip_on_covr()
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   mockery::stub(hintr_run_model, "fit_tmb", fit, depth = 2)
   mockery::stub(hintr_run_model, "sample_tmb", sample, depth = 2)
   mockery::stub(hintr_run_model, "new_progress", MockProgress$new(), depth = 2)
@@ -132,7 +132,7 @@ test_that("progress messages are printed", {
 })
 
 test_that("model run throws error for invalid inputs", {
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   expect_error(
     hintr_run_model(data, a_hintr_options_bad, output_path)
   )
@@ -155,19 +155,19 @@ test_that("setting rng_seed returns same output", {
   options$spectrum_infections_calibration_level <- "none"
   options$calibrate_method <- "logistic"
 
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   model_run <- hintr_run_model(data, options, output_path)
 
   options2 <- options
   options2$rng_seed <- 17
 
-  output_path2 <- tempfile(fileext = ".qs")
+  output_path2 <- tempfile(fileext = ".qs2")
   model_run2 <- hintr_run_model(data, options2, output_path2)
 
   options3 <- options
   options3$rng_seed <- NULL
 
-  output_path3 <- tempfile(fileext = ".qs")
+  output_path3 <- tempfile(fileext = ".qs2")
   model_run3 <- hintr_run_model(data, options3, output_path3)
 
   output <- read_hintr_output(model_run$model_output_path)
@@ -197,7 +197,7 @@ test_that("exceeding max_iterations raises convergence warning", {
   options$artattend <- "false"
   options$max_iterations <- 5
 
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
   expect_warning(
     out <- hintr_run_model(data, options, output_path),
     "convergence error: iteration limit reached without convergence (10)",
@@ -280,8 +280,8 @@ test_that("model run can be calibrated", {
   output_hash <- tools::md5sum(a_hintr_output$model_output_path)
   expect_null(a_hintr_output$plot_data_path)
 
-  plot_data_path <- tempfile(fileext = ".qs")
-  calibration_output_path <- tempfile(fileext = ".qs")
+  plot_data_path <- tempfile(fileext = ".qs2")
+  calibration_output_path <- tempfile(fileext = ".qs2")
   calibrated_output <- hintr_calibrate(a_hintr_output,
                                        a_hintr_calibration_options,
                                        plot_data_path,
@@ -371,8 +371,8 @@ test_that("calibrating model with 'none' returns same results", {
     calibrate_method = "logistic"
   )
 
-  plot_data_path <- tempfile(fileext = ".qs")
-  calibration_output_path <- tempfile(fileext = ".qs")
+  plot_data_path <- tempfile(fileext = ".qs2")
+  calibration_output_path <- tempfile(fileext = ".qs2")
   calibrated_output <- hintr_calibrate(a_hintr_output,
                                        none_calibration_options,
                                        plot_data_path,
@@ -389,16 +389,16 @@ test_that("calibrating model with 'none' returns same results", {
 
 test_that("re-calibrating an already calibrated output throws error", {
 
-  plot_data_path1 <- tempfile(fileext = ".qs")
-  calibration_output_path1 <- tempfile(fileext = ".qs")
+  plot_data_path1 <- tempfile(fileext = ".qs2")
+  calibration_output_path1 <- tempfile(fileext = ".qs2")
   calibrated_output1 <- hintr_calibrate(a_hintr_output,
                                         a_hintr_calibration_options,
                                         plot_data_path1,
                                         calibration_output_path1)
 
   ## Calibrate again with same options using the outputs of calibration 1
-  plot_data_path2 <- tempfile(fileext = ".qs")
-  calibration_output_path2 <- tempfile(fileext = ".qs")
+  plot_data_path2 <- tempfile(fileext = ".qs2")
+  calibration_output_path2 <- tempfile(fileext = ".qs2")
   expect_error(hintr_calibrate(calibrated_output1,
                                a_hintr_calibration_options,
                                plot_data_path2,
@@ -466,7 +466,7 @@ test_that("Model can be run without .shiny90 file", {
   expect_true(validate_model_options(data, opts)$valid)
 
   ## Fit model without .shiny90 in PJNZ
-  output_path <- tempfile(fileext = ".qs")
+  output_path <- tempfile(fileext = ".qs2")
 
   model_run <- hintr_run_model(data,
                                opts,
@@ -669,11 +669,11 @@ test_that("can get data_type labels", {
 test_that("trying to calibrate incompatible model output returns error", {
 
   ## Calibration makes no modification of existing files.
-  plot_data_path <- tempfile(fileext = ".qs")
-  calibration_output_path <- tempfile(fileext = ".qs")
+  plot_data_path <- tempfile(fileext = ".qs2")
+  calibration_output_path <- tempfile(fileext = ".qs2")
   hintr_output <- list(
     plot_data_path = NULL,
-    model_output_path = "refdata/naomi-2.5.5/output_data_2.5.5.qs",
+    model_output_path = "refdata/naomi-2.5.5/output_data_2.5.5.qs2",
     version = "2.5.5"
   )
   class(hintr_output) <- "hintr_output"
@@ -692,7 +692,7 @@ test_that("calibration plot data can be saved as duckdb database", {
   expect_null(a_hintr_output$plot_data_path)
 
   plot_data_path <- tempfile(fileext = ".duckdb")
-  calibration_output_path <- tempfile(fileext = ".qs")
+  calibration_output_path <- tempfile(fileext = ".qs2")
   calibrated_output <- hintr_calibrate(a_hintr_output,
                                        a_hintr_calibration_options,
                                        plot_data_path,

--- a/tests/testthat/test-hintr-plot-data.R
+++ b/tests/testthat/test-hintr-plot-data.R
@@ -33,7 +33,7 @@ test_that("comparison plot returns useful error if run with old naomi output", {
 })
 
 test_that("comparison plot returns useful error if no input output data", {
-  t <- tempfile(fileext = ".qs")
+  t <- tempfile(fileext = ".qs2")
   output_data <- read_hintr_output(a_hintr_output$model_output_path)
   output_data$output_package$inputs_outputs <- NULL
   hintr_save(output_data, t)
@@ -55,13 +55,16 @@ test_that("there is metadata for every indicator in comparison data", {
 
 test_that("hintr data can be saved and read as qs or duckdb type", {
   testthat::skip_if_not_installed("duckdb")
+  testthat::skip_if_not_installed("qs")
 
   t_qs <- tempfile(fileext = ".qs")
+  t_qs2 <- tempfile(fileext = ".qs2")
   t_db <- tempfile(fileext = ".duckdb")
   t_rds <- tempfile(fileext = ".rds")
   d <- data.frame(x = c(1, 2, 3), y = c(4, 5, 6))
 
   hintr_save(d, t_qs)
+  hintr_save(d, t_qs2)
   hintr_save(d, t_db)
   ## Can't use hintr_save for rds as we're no longer serialising as rds
   ## but we could still have historic data saved as rds so we need to
@@ -69,11 +72,12 @@ test_that("hintr data can be saved and read as qs or duckdb type", {
   saveRDS(d, t_rds)
   expect_equal(read_hintr_output(t_rds), d)
   expect_equal(read_hintr_output(t_qs), read_hintr_output(t_db))
+  expect_equal(read_hintr_output(t_qs2), read_hintr_output(t_qs))
   expect_equal(read_hintr_output(t_rds), read_hintr_output(t_qs))
 
   t <- tempfile(fileext = ".thing")
   expect_error(hintr_save(d, t),
-               "Cannot save as type 'thing', must be 'qs' or 'duckdb'.")
+               "Cannot save as type 'thing', must be 'qs2', 'qs' or 'duckdb'.")
 
   x <- list(1, 2, 3)
   expect_error(hintr_save(x, t_db),
@@ -82,5 +86,5 @@ test_that("hintr data can be saved and read as qs or duckdb type", {
 
   expect_error(read_hintr_output(t),
                paste("Cannot read hintr data of invalid type, got 'thing',",
-                     "must be one of rds, qs or duckdb."))
+                     "must be one of rds, qs2, qs or duckdb."))
 })

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -631,8 +631,8 @@ test_that("can generate comparison report with only 1 survey chosen", {
   options <- yaml::read_yaml(text = output$info$options.yml)
   options$survey_prevalence <- options$survey_prevalence[1]
   output$info$options.yml <- yaml::as.yaml(options)
-  out <- tempfile(fileext = ".qs")
-  model_output <- qs::qsave(output, preset = "fast", out)
+  out <- tempfile(fileext = ".qs2")
+  model_output <- qs2::qs_save(output, out)
 
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, out, quiet = TRUE)
@@ -649,8 +649,8 @@ test_that("can generate comparison report without survey ART coverage", {
   options <- yaml::read_yaml(text = output$info$options.yml)
   options$survey_art_coverage <- NULL
   output$info$options.yml <- yaml::as.yaml(options)
-  out <- tempfile(fileext = ".qs")
-  model_output <- qs::qsave(output, preset = "fast", out)
+  out <- tempfile(fileext = ".qs2")
+  model_output <- qs2::qs_save(output, out)
 
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, out, quiet = TRUE)
@@ -672,8 +672,8 @@ test_that("prevalence survey plots not drawn when using aggregate survey", {
   options <- yaml::read_yaml(text = output$info$options.yml)
   options$use_survey_aggregate <- "true"
   output$info$options.yml <- yaml::as.yaml(options)
-  out <- tempfile(fileext = ".qs")
-  model_output <- qs::qsave(output, preset = "fast", out)
+  out <- tempfile(fileext = ".qs2")
+  model_output <- qs2::qs_save(output, out)
 
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, out, quiet = TRUE)
@@ -698,8 +698,8 @@ test_that("prevalence survey plots not drawn when using aggregate survey", {
       indicator == "art_coverage" & calendar_quarter == "CY2020Q3" ~ "CY2019Q3",
       TRUE ~ calendar_quarter))
 
-  out <- tempfile(fileext = ".qs")
-  model_output <- qs::qsave(output, preset = "fast", out)
+  out <- tempfile(fileext = ".qs2")
+  model_output <- qs2::qs_save(output, out)
 
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, out, quiet = TRUE)
@@ -723,8 +723,8 @@ test_that("can generate comparison report with ANC data at T1 not macthed to mod
   options$anc_prevalence_year1 <- "2017"
   options$anc_art_coverage_year1 <- "2017"
   output$info$options.yml <- yaml::as.yaml(options)
-  out <- tempfile(fileext = ".qs")
-  model_output <- qs::qsave(output, preset = "fast", out)
+  out <- tempfile(fileext = ".qs2")
+  model_output <- qs2::qs_save(output, out)
 
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, out, quiet = TRUE)


### PR DESCRIPTION
qs package has been removed from CRAN with no plans to add it back in see https://github.com/qsbase/qs/issues/103. They have an alternative qs2, which inclueds a `qdata` format, but I think that serialization format is not compatible with current qs. We have some data on the deployed web app stored in qs format still, so if we migrate to qs2 we'll need to migrate this data (either to qs2 or duckdb). I'll make a ticket for migrating away from qs.