### PR TITLE
Fix input time series ART aggregation issue reported by Zimbabwe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.10.18
+Version: 2.10.19
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naomi 2.10.19
+
+* Fix issue in input time series ART data prep where "spectrum_level" read from the shape file was being used in calculation instead of a local temporary "spectrum_level" scalar.
+  Fixed this by reading the data using the helper function, which drops the "spectrum_level" column. But also renamed the local variable for good measure.
+
 # naomi 2.10.18
 
 * Add metadata for showing time series aggregated data in choropleth.

--- a/R/input-comparison.R
+++ b/R/input-comparison.R
@@ -61,15 +61,17 @@ prepare_art_spectrum_comparison <- function(art, shape, pjnz) {
                   value_spectrum_adjusted, value_spectrum_reallocated)
 
   # Get spectrum level to select correct area names
+  # TODO: this bit of code reads a little odd, doing an as.integer on a boolean
+  # why do we do this? Is there a better way to write the logic below?
   spectrum_region_code <- unique(shape$spectrum_region_code)
 
-  spectrum_level <- as.integer(length(spectrum_region_code) > 1)
+  level_to_keep <- as.integer(length(spectrum_region_code) > 1)
 
   dat  <- dplyr::left_join(art_agreggated, spec_aggreagted,
                            by = c("spectrum_region_code", "year",
                                   "sex", "age_group")) |>
     dplyr::left_join(shape |>
-                       dplyr::filter(area_level == spectrum_level) |>
+                       dplyr::filter(area_level == level_to_keep) |>
                        dplyr::select(area_name, spectrum_region_code),
                      by = "spectrum_region_code")
 

--- a/R/input-time-series.R
+++ b/R/input-time-series.R
@@ -281,8 +281,8 @@ aggregate_art <- function(art, shape) {
 prepare_input_time_series_art <- function(art, shape, pjnz) {
 
   ## Check if shape is object or file path
-  if(!inherits(shape, "sf")) {
-    areas <- sf::read_sf(shape) |> sf::st_drop_geometry()
+  if(!any(inherits(shape, c("sf", "tbl")))) {
+    areas <- read_area_merged(shape) |> sf::st_drop_geometry()
   } else {
     areas <- shape |> sf::st_drop_geometry()
   }


### PR DESCRIPTION
This is to address issue reported by Isaac via email on Thursday 26th Feb 2026. The actual problem here is quite subtle. 

In the shape file we have a "spectrum_level" column and so when we read this with read_sf it is in the data. When we read with "read_area_merged" it is dropped (so this issue did not appear for the input comparison table and plot). So the problem was, when this was called from the input time series the dplyr function was using the "spectrum_level" column instead of the locally defined "spectrum_level" variable. I've fixed this by reading in input time series with our helper function, and renaming the local variable. I would like to review the code with Rachel too when she is back, but this fixes the problem for now.