### PR TITLE
Fix anc areas display t4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tests/testthat/testdata/fit.RDS
 .vscode
 .Rprofile
 .idea
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.10.19
+Version: 2.10.20
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# naomi 2.10.20
+* Fix `read_anc_testing()` to replace individual `NA` values in `anc_known_neg` with `0`. Previously only the all-`NA` case was handled; partially-populated
+  columns (e.g. data available for recent years only) caused `anc_prev_n` to be `NA` for missing rows, which were then silently dropped, triggering
+  a "Column `anc_prev_n` doesn't exist" error in `anc_testing_prev_mf()`.
+* Remove requirement for deprecated "disply" column in areas file
+* Report of mode fro T4 indicators in model fit
+
+
 # naomi 2.10.19
 
 * Fix issue in input time series ART data prep where "spectrum_level" read from the shape file was being used in calculation instead of a local temporary "spectrum_level" scalar.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # naomi 2.10.20
+
 * Fix `read_anc_testing()` to replace individual `NA` values in `anc_known_neg` with `0`. Previously only the all-`NA` case was handled; partially-populated
   columns (e.g. data available for recent years only) caused `anc_prev_n` to be `NA` for missing rows, which were then silently dropped, triggering
   a "Column `anc_prev_n` doesn't exist" error in `anc_testing_prev_mf()`.
-* Remove requirement for deprecated "display" column in areas file
-* Report of mode fro T4 indicators in model fit
+* Remove requirement for deprecated "display" column in areas file.
+* Report of mode for T4 indicators in model fit.
 
 
 # naomi 2.10.19

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 * Fix `read_anc_testing()` to replace individual `NA` values in `anc_known_neg` with `0`. Previously only the all-`NA` case was handled; partially-populated
   columns (e.g. data available for recent years only) caused `anc_prev_n` to be `NA` for missing rows, which were then silently dropped, triggering
   a "Column `anc_prev_n` doesn't exist" error in `anc_testing_prev_mf()`.
-* Remove requirement for deprecated "disply" column in areas file
+* Remove requirement for deprecated "display" column in areas file
 * Report of mode fro T4 indicators in model fit
 
 

--- a/R/areas.R
+++ b/R/areas.R
@@ -36,7 +36,7 @@ create_areas <- function(levels = NULL, hierarchy = NULL, boundaries = NULL,
 
     levels <- area_merged %>%
       as.data.frame() %>%
-      dplyr::count(area_level, area_level_label, display, name = "n_areas")
+      dplyr::count(area_level, area_level_label, name = "n_areas")
     hierarchy <- area_merged %>%
       as.data.frame() %>%
       dplyr::select(area_id, area_name, area_level, parent_area_id, spectrum_region_code, area_sort_order, center_x, center_y)
@@ -145,7 +145,6 @@ create_areas <- function(levels = NULL, hierarchy = NULL, boundaries = NULL,
   tree$Set(area_id = hierarchy$area_id,
            area_level = hierarchy$area_level,
            area_level_label = hierarchy$area_level_label,
-           display_level = hierarchy$display,
            spectrum_region_code = hierarchy$spectrum_region_code,
            area_name = hierarchy$area_name,
            area_sort_order = hierarchy$area_sort_order,

--- a/R/read-data.R
+++ b/R/read-data.R
@@ -177,9 +177,16 @@ read_anc_testing <- function(file) {
   if(length(missing_cols))
     stop(paste0("Required columns not found: ", paste(missing_cols, collapse = ", ")))
 
-  if ( !("anc_known_neg" %in% names(val)) ||
-         all(is.na(val[["anc_known_neg"]])) ) {
+  if ( !("anc_known_neg" %in% names(val)) ) {
     val[["anc_known_neg"]] <- 0
+  } else {
+    ## Replace individual NA values with 0. The column may be partially
+    ## populated (e.g. data only available for recent years) so the
+    ## all(is.na()) check is insufficient. Propagating NAs through to
+    ## anc_prev_n causes those rows to be silently dropped, which then
+    ## causes select("anc_prev_n") to fail in anc_testing_prev_mf() when
+    ## pivot_wider finds no rows for that indicator.
+    val[["anc_known_neg"]][is.na(val[["anc_known_neg"]])] <- 0
   }
 
   if ( !("births_facility" %in% names(val)) ) {
@@ -203,7 +210,7 @@ read_area_merged <- function(file) {
 
   val <- sf::read_sf(file)
   val <- dplyr::select(val, area_id, area_name, area_level, parent_area_id, spectrum_region_code, area_sort_order,
-                       center_x, center_y, area_level_label, display, geometry)
+                       center_x, center_y, area_level_label, geometry)
 
   ## !! TODO: coerce column types
   ## !! TODO: add validation asserts -- probably pull in hintr validation_asserts.R

--- a/R/tmb-model-r-implementation.R
+++ b/R/tmb-model-r-implementation.R
@@ -655,7 +655,6 @@ naomi_objective_function_r <- function(d, p) {
   anc_plhiv_t3 <- anc_clients_t3 * anc_rho_t3
   anc_already_art_t3 <- anc_plhiv_t3 * anc_alpha_t3
 
-
   prop_art_ij_t3 <- as.vector(d$Xart_idx %*% prop_art_t3) * as.vector(d$Xart_gamma %*% gamma_art_t2)  ## Note: using same ART attendance as T2
   population_ij_t3 <- as.vector(d$Xart_idx %*% d$population_t3)
   artnum_ij_t3 <- population_ij_t3 * prop_art_ij_t3
@@ -727,7 +726,6 @@ naomi_objective_function_r <- function(d, p) {
                     anc_alpha_t3_out               = anc_alpha_t3_out)
 
   ## Projection to time 4
-
   mu_alpha_t4 <- mu_alpha_t3 + d$logit_alpha_t3t4_offset
   alpha_t4 <- plogis(mu_alpha_t4)
 
@@ -739,6 +737,7 @@ naomi_objective_function_r <- function(d, p) {
   rho_t4 <- plhiv_t4 / d$population_t4
   prop_art_t4 <- rho_t4 * alpha_t4
   artnum_t4 <- d$population_t4 * prop_art_t4
+
 
   plhiv_15to49_t4 <- as.vector(d$X_15to49 %*% plhiv_t4)
   rho_15to49_t4 <- plhiv_15to49_t4 / as.vector(d$X_15to49 %*% d$population_t4)
@@ -781,15 +780,21 @@ naomi_objective_function_r <- function(d, p) {
   prop_art_ij_t4 <- as.vector(d$Xart_idx %*% prop_art_t4) * as.vector(d$Xart_gamma %*% gamma_art_t2)  ## Note: using same ART attendance as T2
   population_ij_t4 <- as.vector(d$Xart_idx %*% d$population_t4)
   artnum_ij_t4 <- population_ij_t4 * prop_art_ij_t4
+  artattend_ij_t4 <- as.vector(d$A_art_reside_attend %*% artnum_ij_t4)
 
   population_t4_out <- as.vector(d$A_out %*% d$population_t4)
   plhiv_t4_out <- as.vector(d$A_out %*% plhiv_t4)
+  rho_t4_out <- plhiv_t4_out / population_t4_out
+  artnum_t4_out <- as.vector(d$A_out %*% artnum_t4)
+  alpha_t4_out <- artnum_t4_out / plhiv_t4_out
+  artattend_t4_out <- as.vector(d$A_out %*% (d$A_artattend_mf %*% artnum_ij_t4))
+  artattend_ij_t4_out <- as.vector(d$A_art_reside_attend %*% artnum_ij_t4)
+  untreated_plhiv_num_t4_out <- plhiv_t4_out - artnum_t4_out
 
   ## Calculate number of PLHIV who would attend facility in district i
   plhiv_attend_ij_t4 <- as.vector(d$Xart_idx %*% plhiv_t4) * as.vector(d$Xart_gamma %*% gamma_art_t2)
   plhiv_attend_t4_out <- as.vector(d$A_out %*% (d$A_artattend_mf %*% plhiv_attend_ij_t4))
-
-
+  untreated_plhiv_attend_t4_out <- plhiv_attend_t4_out - artattend_t4_out
 
   infections_t4_out <- as.vector(d$A_out %*% infections_t4)
   lambda_t4_out <- infections_t4_out / (population_t4_out - plhiv_t4_out)
@@ -893,9 +898,9 @@ bym2_conditional_lpdf <- function(x, u, sigma, phi, Q) {
 #' ldbinom(c(1.2, 3, 1.9), c(7.5, 12.4, 4), c(0.3, 0.2, 0.7))
 #'
 #' ## For integer counts, returns same as dbinom(..., log = TRUE)
-#' x <- c(1, 3, 2)
+#' x <- c(1, 4, 2)
 #' size <- c(7, 12, 4)
-#' prob <- c(0.3, 0.2, 0.7)
+#' prob <- c(0.4, 0.2, 0.7)
 #' ldbinom(x, size, prob)
 #' dbinom(x, size, prob, log = TRUE)
 #'

--- a/R/tmb-model-r-implementation.R
+++ b/R/tmb-model-r-implementation.R
@@ -818,7 +818,15 @@ naomi_objective_function_r <- function(d, p) {
                     anc_tested_pos_t4_out          = anc_tested_pos_t4_out,
                     anc_tested_neg_t4_out          = anc_tested_neg_t4_out,
                     anc_rho_t4_out                 = anc_rho_t4_out,
-                    anc_alpha_t4_out               = anc_alpha_t4_out)
+                    anc_alpha_t4_out               = anc_alpha_t4_out,
+                    rho_t4_out                     = rho_t4_out,
+                    artnum_t4_out                  = artnum_t4_out,
+                    artattend_ij_t4_out            = artattend_ij_t4_out,
+                    alpha_t4_out                   = alpha_t4_out,
+                    untreated_plhiv_num_t4_out     = untreated_plhiv_num_t4_out,
+                    untreated_plhiv_attend_t4_out  = untreated_plhiv_attend_t4_out,
+                    artattend_t4_out               = artattend_t4_out)
+
 
   report_likelihood <- list(hhs_prev_ll           = hhs_prev_ll,
                             hhs_artcov_ll         = hhs_artcov_ll,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -67,7 +67,7 @@ utils::globalVariables(c(
   ".data", "dataelement_uid", "datapack_age_group_id",
   "datapack_age_group_label", "datapack_indicator_code",
   "datapack_indicator_id", "datapack_sex_id", "datapack_sex_label",
-  "data_range", "data_type", "display", "distribution",
+  "data_range", "data_type", "distribution",
   "district_rse", "element_blank",
   "est_calibrated", "estimate", "est_raw", "female_15plus", "fit",
   "frr_already_art", "frr_plhiv", "geometry", "hivpop", "hivpop1", "hivpop2",

--- a/src/tmb.cpp
+++ b/src/tmb.cpp
@@ -1046,17 +1046,17 @@ Type objective_function<Type>::operator() ()
 
     vector<Type> population_t4_out(A_out * population_t4);
     vector<Type> plhiv_t4_out(A_out * plhiv_t4);
-    // vector<Type> rho_t4_out(plhiv_t4_out / population_t4_out);
-    // vector<Type> artnum_t4_out(A_out * artnum_t4);
-    // vector<Type> alpha_t4_out(artnum_t4_out / plhiv_t4_out);
-    // vector<Type> artattend_t4_out(A_out * (A_artattend_mf * artnum_ij_t4));
-    // vector<Type> artattend_ij_t4_out(A_art_reside_attend * artnum_ij_t4);
-    // vector<Type> untreated_plhiv_num_t4_out(plhiv_t4_out - artnum_t4_out);
+    vector<Type> rho_t4_out(plhiv_t4_out / population_t4_out);
+    vector<Type> artnum_t4_out(A_out * artnum_t4);
+    vector<Type> alpha_t4_out(artnum_t4_out / plhiv_t4_out);
+    vector<Type> artattend_t4_out(A_out * (A_artattend_mf * artnum_ij_t4));
+    vector<Type> artattend_ij_t4_out(A_art_reside_attend * artnum_ij_t4);
+    vector<Type> untreated_plhiv_num_t4_out(plhiv_t4_out - artnum_t4_out);
 
     // Calculate number of PLHIV who attend facility in district i; denominator for artattend
     vector<Type> plhiv_attend_ij_t4((Xart_idx * plhiv_t4) * (Xart_gamma * gamma_art_t2));    // Note: using same ART attendance as T2
     vector<Type> plhiv_attend_t4_out(A_out * (A_artattend_mf * plhiv_attend_ij_t4));
-    // vector<Type> untreated_plhiv_attend_t4_out(plhiv_attend_t4_out - artattend_t4_out);
+    vector<Type> untreated_plhiv_attend_t4_out(plhiv_attend_t4_out - artattend_t4_out);
 
     vector<Type> infections_t4_out(A_out * infections_t4);
     vector<Type> lambda_t4_out(infections_t4_out / (population_t4_out - plhiv_t4_out));
@@ -1074,15 +1074,15 @@ Type objective_function<Type>::operator() ()
 
 
     REPORT(population_t4_out);
-    // REPORT(rho_t4_out);
+    REPORT(rho_t4_out);
     REPORT(plhiv_t4_out);
-    // REPORT(alpha_t4_out);
-    // REPORT(artnum_t4_out);
-    // REPORT(artattend_t4_out);
-    // REPORT(artattend_ij_t4_out);
-    // REPORT(untreated_plhiv_num_t4_out);
+    REPORT(alpha_t4_out);
+    REPORT(artnum_t4_out);
+    REPORT(artattend_t4_out);
+    REPORT(artattend_ij_t4_out);
+    REPORT(untreated_plhiv_num_t4_out);
     REPORT(plhiv_attend_t4_out);
-    // REPORT(untreated_plhiv_attend_t4_out);
+    REPORT(untreated_plhiv_attend_t4_out);
     REPORT(lambda_t4_out);
     REPORT(infections_t4_out);
 

--- a/tests/testthat/test-read-data.R
+++ b/tests/testthat/test-read-data.R
@@ -127,4 +127,23 @@ test_that("read_anc_testing() handles data set without 'anc_known_neg' or 'birth
 
   expect_equal(calculate_anc_prevalence(raw),
                calculate_anc_prevalence(anc_na_known_neg))
+
+  ## Column anc_known_neg exists with partial NAs (e.g. only populated for
+  ## recent years). Previously the all(is.na()) guard did not catch this case,
+  ## so NAs propagated into anc_prev_n and those rows were silently dropped,
+  ## causing select("anc_prev_n") to fail in anc_testing_prev_mf().
+  new3 <- raw
+  new3$anc_tested <- raw$anc_tested + raw$anc_known_neg
+  ## Set only the first half of rows to NA, leaving the rest with real values
+  half <- floor(nrow(raw) / 2)
+  new3$anc_known_neg[seq_len(half)] <- NA_real_
+
+  f3 <- tempfile(fileext = ".csv")
+  readr::write_csv(new3, f3, na = "")
+
+  anc_partial_known_neg <- read_anc_testing(f3)
+
+  expect_equal(anc_partial_known_neg$anc_known_neg[seq_len(half)],
+               rep(0.0, half))
+  expect_true(all(!is.na(anc_partial_known_neg$anc_known_neg)))
 })


### PR DESCRIPTION
* Fix `read_anc_testing()` to replace individual `NA` values in `anc_known_neg` with `0`. Previously only the all-`NA` case was handled; partially-populated
  columns (e.g. data available for recent years only) caused `anc_prev_n` to be `NA` for missing rows, which were then silently dropped, triggering
  a "Column `anc_prev_n` doesn't exist" error in `anc_testing_prev_mf()`.
* Remove requirement for deprecated "display" column in areas file
* Report of mode fro T4 indicators in model fit