### PR TITLE
Remove qs dependency - it can no longer be installed on latest version of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Suggests:
     lubridate,
     mockery,
     mockr,
-    qs,
     readxl,
     rvest,
     scales,
@@ -78,7 +77,6 @@ LinkingTo:
     RcppEigen,
     TMB
 Remotes:
-    bergant/datamodelr,
-    qsbase/qs
+    bergant/datamodelr
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi
 Title: Naomi Model for Subnational HIV Estimates
-Version: 2.10.20
+Version: 2.10.21
 Authors@R:
     person(given = "Jeff",
            family = "Eaton",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi 2.10.21
+
+* Remove qs package, it is no longer installable in R 4.5.x
+
 # naomi 2.10.20
 
 * Fix `read_anc_testing()` to replace individual `NA` values in `anc_known_neg` with `0`. Previously only the all-`NA` case was handled; partially-populated

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1344,7 +1344,7 @@ get_period_metadata <- function(calendar_quarters) {
 
 #' Read hintr output
 #'
-#' Read the hintr model output or plot data saved as a qs or an rds file.
+#' Read the hintr model output or plot data saved as a qs2, duckdb or rds file.
 #' This is the data saved from hintr_run_model or hintr_calibrate
 #' before the output zip is generated. This uses the file extension
 #' to identify the reading function to use.
@@ -1357,9 +1357,6 @@ read_hintr_output <- function(path) {
   type <- tolower(tools::file_ext(path))
   if (type == "qs2") {
     qs2::qs_read(path)
-  } else if (type == "qs") {
-    assert_package_installed("qs")
-    qs::qread(path)
   } else if (type == "duckdb") {
     read_duckdb(path)
   } else if (type == "rds") {
@@ -1367,7 +1364,7 @@ read_hintr_output <- function(path) {
     readRDS(path)
   } else {
     stop(sprintf(paste("Cannot read hintr data of invalid type, got '%s',",
-                       "must be one of rds, qs2, qs or duckdb."), type))
+                       "must be one of rds, qs2 or duckdb."), type))
   }
 }
 

--- a/R/run-model.R
+++ b/R/run-model.R
@@ -5,7 +5,7 @@
 #'
 #' @param data List of paths to input data files.
 #' @param options List of model run options (see details).
-#' @param model_output_path Path to store model output as qs. Used in
+#' @param model_output_path Path to store model output as qs2. Used in
 #'   calibrating model and producing output downloads.
 #' @param validate If FALSE validation of inputs & data will be skipped.
 #'
@@ -151,9 +151,6 @@ hintr_save <- function(obj, file) {
   type <- tolower(tools::file_ext(file))
   if (type == "qs2") {
     qs2::qs_save(obj, file)
-  } else if (type == "qs") {
-    assert_package_installed("qs")
-    qs::qsave(obj, file, preset = "fast")
   } else if (type == "duckdb") {
     if (!is.data.frame(obj)) {
       stop(paste("Trying to save invalid object as duckdb database.",
@@ -164,7 +161,7 @@ hintr_save <- function(obj, file) {
     on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
     DBI::dbWriteTable(con, DUCKDB_OUTPUT_TABLE_NAME, obj)
   } else {
-    stop(sprintf("Cannot save as type '%s', must be 'qs2', 'qs' or 'duckdb'.",
+    stop(sprintf("Cannot save as type '%s', must be 'qs2' or 'duckdb'.",
                  type))
   }
 }
@@ -186,7 +183,7 @@ assert_model_output_version <- function(obj, version = NULL) {
 #'
 #' @param output A hintr_output object.
 #' @param calibration_options A set of calibration options
-#' @param plot_data_path Path to store calibrated output indicators as a qs.
+#' @param plot_data_path Path to store calibrated output indicators as a qs2.
 #' @param calibrate_output_path Path to store data required for re-calibrating model.
 #'
 #' @return Calibrated hintr_output object

--- a/inst/report/comparison_report.Rmd
+++ b/inst/report/comparison_report.Rmd
@@ -37,7 +37,7 @@ options(scipen=10000000)
 outputs <- params$outputs
 
 # Read files if hintr rds provided
-if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs", "qs2")) {
+if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs2")) {
 
   model_object <- read_hintr_output(outputs)
   outputs <- model_object$output_package

--- a/inst/report/summary_report.Rmd
+++ b/inst/report/summary_report.Rmd
@@ -39,7 +39,7 @@ title: `r title`
 options(scipen=10000000)
 
 # Read files if hintr rds provided
-if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs", "qs2")) {
+if(tolower(tools::file_ext(params$outputs)) %in% c("rds", "qs2")) {
   
   model_object <- read_hintr_output(params$outputs)
   outputs <- model_object$output_package

--- a/tests/testthat/test-hintr-plot-data.R
+++ b/tests/testthat/test-hintr-plot-data.R
@@ -53,17 +53,14 @@ test_that("there is metadata for every indicator in comparison data", {
   expect_setequal(indicators, comparison$indicator)
 })
 
-test_that("hintr data can be saved and read as qs or duckdb type", {
+test_that("hintr data can be saved and read as qs2 or duckdb type", {
   testthat::skip_if_not_installed("duckdb")
-  testthat::skip_if_not_installed("qs")
 
-  t_qs <- tempfile(fileext = ".qs")
   t_qs2 <- tempfile(fileext = ".qs2")
   t_db <- tempfile(fileext = ".duckdb")
   t_rds <- tempfile(fileext = ".rds")
   d <- data.frame(x = c(1, 2, 3), y = c(4, 5, 6))
 
-  hintr_save(d, t_qs)
   hintr_save(d, t_qs2)
   hintr_save(d, t_db)
   ## Can't use hintr_save for rds as we're no longer serialising as rds
@@ -71,13 +68,12 @@ test_that("hintr data can be saved and read as qs or duckdb type", {
   ## be able to read it
   saveRDS(d, t_rds)
   expect_equal(read_hintr_output(t_rds), d)
-  expect_equal(read_hintr_output(t_qs), read_hintr_output(t_db))
-  expect_equal(read_hintr_output(t_qs2), read_hintr_output(t_qs))
-  expect_equal(read_hintr_output(t_rds), read_hintr_output(t_qs))
+  expect_equal(read_hintr_output(t_qs2), read_hintr_output(t_db))
+  expect_equal(read_hintr_output(t_rds), read_hintr_output(t_qs2))
 
   t <- tempfile(fileext = ".thing")
   expect_error(hintr_save(d, t),
-               "Cannot save as type 'thing', must be 'qs2', 'qs' or 'duckdb'.")
+               "Cannot save as type 'thing', must be 'qs2' or 'duckdb'.")
 
   x <- list(1, 2, 3)
   expect_error(hintr_save(x, t_db),
@@ -86,5 +82,5 @@ test_that("hintr data can be saved and read as qs or duckdb type", {
 
   expect_error(read_hintr_output(t),
                paste("Cannot read hintr data of invalid type, got 'thing',",
-                     "must be one of rds, qs2, qs or duckdb."))
+                     "must be one of rds, qs2 or duckdb."))
 })

--- a/tests/testthat/test-outputs.R
+++ b/tests/testthat/test-outputs.R
@@ -190,7 +190,7 @@ test_that("subset_output_package() saves expected output package", {
 
 })
 
-test_that("can generate summary report from a qs file", {
+test_that("can generate summary report from a qs2 file", {
   t <- tempfile(fileext = ".html")
   generate_output_summary_report(t, a_hintr_output_calibrated$model_output_path,
                                  quiet = TRUE)
@@ -602,7 +602,7 @@ test_that("output file README generated in output zip", {
   expect_true(any(grepl("The following files have been generated as part of a Naomi model fit:" , content)))
 })
 
-test_that("can generate comparison report from a qs file", {
+test_that("can generate comparison report from a qs2 file", {
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, a_hintr_output_calibrated$model_output_path,
                              quiet = TRUE)
@@ -613,7 +613,7 @@ test_that("can generate comparison report from a qs file", {
   expect_true(any(grepl("class=\"logo-naomi\"", content)))
 })
 
-test_that("can generate summary report from zip file", {
+test_that("can generate comparison report from zip file", {
   zip <- hintr_prepare_spectrum_download(a_hintr_output_calibrated)
   t <- tempfile(fileext = ".html")
   generate_comparison_report(t, zip$path, quiet = TRUE)
@@ -688,7 +688,7 @@ test_that("prevalence survey plots not drawn when using aggregate survey", {
   expect_length(rvest::html_element(html, ".art-plotly"), 2)
 })
 
-test_that("prevalence survey plots not drawn when using aggregate survey", {
+test_that("prevalence survey plots not drawn when using aggregate survey CMR", {
   ## This is to address Cameroon 2022/2023 issue #41
   ## Create a model output with different ART time to prevalence
   output <- read_hintr_output(a_hintr_output_calibrated$model_output_path)


### PR DESCRIPTION
We'll also need to migrate the files on the server. 

qs package has been deprecated, and we made it an optional dependency to preserve reading old files from the server. But now you can no longer install it on the latest version of R, so we have to rip it out and do the migration.